### PR TITLE
fix(ui): refresh active project metadata after rename

### DIFF
--- a/src/hooks/useProjectsState.test.ts
+++ b/src/hooks/useProjectsState.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import type { Project } from '../types/app';
 
-import { projectsHaveChanges, readProjectsResponse } from './useProjectsState';
+import { projectsHaveChanges, readProjectsResponse, reconcileSelectedProject } from './useProjectsState';
 
 const autoProject: Project = {
   projectId: 'project-1',
@@ -52,4 +52,34 @@ test('readProjectsResponse rejects ok responses whose body is not an array', asy
 
   assert.equal(await readProjectsResponse(objectBody, 'refreshing'), null);
   assert.equal(await readProjectsResponse(invalidJson, 'refreshing'), null);
+});
+
+test('reconcileSelectedProject applies refreshed display metadata to the active project', () => {
+  const renamedProject = { ...autoProject, displayName: 'Renamed project' };
+
+  const reconciled = reconcileSelectedProject(autoProject, [renamedProject]);
+
+  assert.equal(reconciled?.displayName, 'Renamed project');
+});
+
+test('reconcileSelectedProject preserves expanded session pages during metadata refresh', () => {
+  const loadedProject: Project = {
+    ...autoProject,
+    sessions: [
+      { id: 'session-1', summary: 'First' },
+      { id: 'session-2', summary: 'Second' },
+    ],
+    sessionMeta: { hasMore: false, total: 2 },
+  };
+  const renamedProject: Project = {
+    ...autoProject,
+    displayName: 'Renamed project',
+    sessions: [{ id: 'session-1', summary: 'First' }],
+    sessionMeta: { hasMore: true, total: 2 },
+  };
+
+  const reconciled = reconcileSelectedProject(loadedProject, [renamedProject]);
+
+  assert.equal(reconciled?.displayName, 'Renamed project');
+  assert.deepEqual(reconciled?.sessions?.map((session) => session.id), ['session-1', 'session-2']);
 });

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -182,6 +182,27 @@ const mergeExpandedSessionPages = (previousProjects: Project[], incomingProjects
   });
 };
 
+export const reconcileSelectedProject = (
+  previousProject: Project | null,
+  freshProjects: Project[],
+): Project | null => {
+  if (!previousProject) {
+    return null;
+  }
+
+  const freshProject = freshProjects.find(
+    (project) => project.projectId === previousProject.projectId,
+  );
+  if (!freshProject) {
+    return previousProject;
+  }
+
+  const [mergedProject] = mergeExpandedSessionPages([previousProject], [freshProject]);
+  return projectsHaveChanges([previousProject], [mergedProject])
+    ? mergedProject
+    : previousProject;
+};
+
 const mergeProjectSessionPage = (
   existingProject: Project,
   sessionsPage: ProjectSessionPage,
@@ -454,6 +475,10 @@ export function useProjectsState({
       if (!projectData) {
         return;
       }
+
+      setSelectedProject((previousProject) =>
+        reconcileSelectedProject(previousProject, projectData),
+      );
 
       setProjects((prevProjects) => {
         const mergedProjects = mergeExpandedSessionPages(prevProjects, projectData);


### PR DESCRIPTION
## Summary
- reconcile the active project with freshly fetched project metadata
- keep expanded session pages intact while applying a renamed display name
- add regression coverage for rename synchronization and expanded-session preservation

## CUA reproduction
1. Select a project.
2. Rename it from the sidebar.
3. Before this fix, the sidebar changed immediately but the document title and active-project header retained the old name until the project was reselected.
4. With this fix, the sidebar and document title update together (`CUA Project Fixed - Gajae Code App`).

## Verification
- `node --import tsx --test src/hooks/useProjectsState.test.ts` (7 passed)
- `npm run typecheck`
- `npx eslint src/hooks/useProjectsState.ts src/hooks/useProjectsState.test.ts`
- CUA: renamed selected project and confirmed title updated without reselection
