### PR TITLE
fix(gjc): let desktop runs use GJC config-key providers

### DIFF
--- a/server/gjc-bun-sdk-adapter.ts
+++ b/server/gjc-bun-sdk-adapter.ts
@@ -142,6 +142,23 @@ function configFromOptions(value: Record<string, unknown>): SdkRunConfig {
   return candidate as unknown as SdkRunConfig;
 }
 
+/**
+ * Desktop runs are single-operator: the app is a shell over the operator's own
+ * `~/.gjc` install, so a provider whose key comes from that install's
+ * `models.yml` (`apiKey` / `apiKeyEnv`) is exactly as legitimate as a stored
+ * credential row. Shared server deployments stay fail-closed on stored rows so
+ * one signed-in app user can never spend the host operator's ambient keys.
+ *
+ * Only an unpinned reference qualifies. An explicit `providerId` or
+ * `credentialId` is an assertion about stored rows and still fails closed.
+ */
+function configCredentialsAllowed(credential: ExactCredentialRef): boolean {
+  return credential.kind === 'stored'
+    && credential.providerId === undefined
+    && credential.credentialId === undefined
+    && process.env.GJC_DESKTOP === '1';
+}
+
 function modelsForCredential(
   authStorage: AuthStorage,
   modelRegistry: ModelRegistry,
@@ -149,6 +166,9 @@ function modelsForCredential(
 ): Model[] {
   const available = modelRegistry.getAvailable();
   if (credential.kind === 'runtime-env') return available;
+  // The SDK's availability set already accounts for stored rows, config keys,
+  // and env-var keys; narrowing it further would hide config-key providers.
+  if (configCredentialsAllowed(credential)) return available;
 
   const rows: Array<{ id: number; provider: string }> = authStorage.exportSnapshot().credentials;
   const eligibleProviders = new Set(
@@ -229,7 +249,12 @@ function credentialFor(
     const rows = snapshotRows
       .filter((row) => row.provider === model.provider)
       .sort((left, right) => left.id - right.id);
-    if (rows.length === 0) throw new Error(FAILURE);
+    if (rows.length === 0) {
+      // No stored row: on desktop, defer to the provider's configured key by
+      // installing no selector (the same shape the runtime-env branch returns).
+      if (configCredentialsAllowed(credential)) return { dispose() {} };
+      throw new Error(FAILURE);
+    }
     // Deterministic selection: explicit credentialId wins; otherwise the lowest
     // stored row id. Installing a selector also blocks the env-var fallback.
     const row = credential.credentialId !== undefined

--- a/server/gjc-sdk-contract.bun.test.ts
+++ b/server/gjc-sdk-contract.bun.test.ts
@@ -1454,11 +1454,17 @@ test('explicit SDK configuration rejects missing fields, unresolvable credential
       assert.equal((response(f.frames, `invalid-${index}`).payload as Record<string, unknown>).ok, false);
     }
     assert.equal(f.sessions.length, 0);
-    // Zero stored rows for the model provider stays fail-closed.
-    f.authStorage.credentials = [];
-    await f.host.handle(request('session.start', 'invalid-zero-rows', { message: 'x', options: { ...f.options, credential: { kind: 'stored' } } }));
-    assert.equal((response(f.frames, 'invalid-zero-rows').payload as Record<string, unknown>).ok, false);
-    assert.equal(f.sessions.length, 0);
+    // Zero stored rows for the model provider stays fail-closed off desktop.
+    const desktop = process.env.GJC_DESKTOP;
+    delete process.env.GJC_DESKTOP;
+    try {
+      f.authStorage.credentials = [];
+      await f.host.handle(request('session.start', 'invalid-zero-rows', { message: 'x', options: { ...f.options, credential: { kind: 'stored' } } }));
+      assert.equal((response(f.frames, 'invalid-zero-rows').payload as Record<string, unknown>).ok, false);
+      assert.equal(f.sessions.length, 0);
+    } finally {
+      if (desktop === undefined) delete process.env.GJC_DESKTOP; else process.env.GJC_DESKTOP = desktop;
+    }
     // Multiple stored rows resolve deterministically to the lowest row id.
     f.authStorage.credentials = [
       { id: 7, provider: 'contract-provider' },
@@ -1476,6 +1482,38 @@ test('explicit SDK configuration rejects missing fields, unresolvable credential
       credentialId: 2,
     });
   } finally { await f.close(); }
+});
+
+test('desktop runs accept a provider whose key comes from the GJC config instead of a stored row', async () => {
+  const f = await fixture();
+  const desktop = process.env.GJC_DESKTOP;
+  process.env.GJC_DESKTOP = '1';
+  try {
+    // The operator's own ~/.gjc install authenticates this provider through
+    // models.yml (apiKey / apiKeyEnv), so it never gets a stored row.
+    f.authStorage.credentials = [];
+    const run = f.host.handle(request('session.start', 'desktop-config-key', { message: 'x', options: { ...f.options, credential: { kind: 'stored' } } }));
+    const session = await firstSession(f.sessions);
+    session.complete();
+    await run;
+
+    const payload = response(f.frames, 'desktop-config-key').payload as Record<string, unknown>;
+    assert.equal(payload.ok, true);
+    // No selector is installed, which is what lets the SDK use the configured key.
+    const factoryInput = f.factoryOptions.at(-1) as { credentialSelector?: unknown };
+    assert.equal(factoryInput.credentialSelector, undefined);
+    assert.equal((payload.result as Record<string, unknown>).credential, undefined);
+
+    // A pinned reference is an assertion about stored rows and still fails closed.
+    for (const [index, credential] of [{ kind: 'stored', providerId: 'contract-provider' }, { kind: 'stored', credentialId: 4 }].entries()) {
+      await f.host.handle(request('session.start', `desktop-pinned-${index}`, { message: 'x', options: { ...f.options, credential } }));
+      assert.equal((response(f.frames, `desktop-pinned-${index}`).payload as Record<string, unknown>).ok, false);
+    }
+    assert.equal(f.sessions.length, 1);
+  } finally {
+    if (desktop === undefined) delete process.env.GJC_DESKTOP; else process.env.GJC_DESKTOP = desktop;
+    await f.close();
+  }
 });
 
 test('ask bridge rejects duplicate and stale replies and cancels pending permission on dispose', async () => {


### PR DESCRIPTION
## What breaks today

On a fresh desktop install (2.0.0-beta.6, macOS arm64), every turn dies with the generic `GJC worker failed.` bubble while the same `~/.gjc` install runs fine in the CLI.

`~/.gajae-app/logs/gjc-worker.log`:

```
run run-210016b6-... failed: Error: GJC SDK configuration is invalid.
    at configuredDefaultModelId (server/gjc-bun-sdk-adapter.js:98:19)
```

Cause: `gjc-worker-client.ts` defaults a run to `credential: { kind: 'stored' }`, and `modelsForCredential()` then narrows `ModelRegistry.getAvailable()` to providers that have a row in the SDK auth storage. A provider the operator's own install authenticates through `models.yml` (`apiKey` / `apiKeyEnv`) has no such row, so it disappears from the candidate set, `settings.getModelRole('default')` resolves to nothing, and the adapter throws. `credentialFor()` fails the same way one step later (`rows.length === 0`).

## Reproduce

`~/.gjc/agent/models.yml`:

```yaml
providers:
  acme-anthropic:
    baseUrl: https://api.example.com/v1
    apiKeyEnv: ACME_API_KEY
    api: anthropic-messages
    auth: apiKey
    models:
      - id: some-model
```

`~/.gjc/agent/config.yml`: `modelRoles.default: acme-anthropic/some-model`. No stored credential for `acme-anthropic` (the key lives in the shell env / config, as the CLI expects).

CLI: works. App: `GJC worker failed.` on every message.

Checked against the same install with the bundled SDK:

```
role: acme-anthropic/some-model -> resolved: acme-anthropic/some-model      # unfiltered
role: acme-anthropic/some-model -> resolved: null                          # stored-row filter
```

Storing the key as a credential row instead is not a workaround — the SDK then refuses it with `Credential selector id:N cannot be used for acme-anthropic while a config API key override is active`, and dropping `apiKeyEnv` removes the provider from the registry entirely.

## The change

An **unpinned** `{ kind: 'stored' }` reference in desktop mode (`GJC_DESKTOP=1`) now falls through to the SDK's own availability and credential resolution: no selector is installed, so the provider's configured key applies — the same shape the `runtime-env` branch already returns.

Deliberately unchanged:

- Server / self-host mode stays fail-closed on stored rows, so one signed-in app user can never spend the host operator's ambient keys.
- An explicit `providerId` or `credentialId` is an assertion about stored rows and still fails closed, on desktop too.
- Providers that do have stored rows keep the existing deterministic lowest-row-id selection.

## Tests

`server/gjc-sdk-contract.bun.test.ts`:

- new: desktop + zero stored rows + config-key provider → run starts, no `credentialSelector` reaches the factory, no credential echoed back; pinned `providerId` / `credentialId` still fail closed.
- existing zero-row fail-closed assertion is now hermetic against an ambient `GJC_DESKTOP`.

`bun test server/gjc-sdk-contract.bun.test.ts` → 55 pass / 1 skip. The 2 failures in that file on my machine are pre-existing on `main` and environmental (`dist-native/bun` not built). `npx tsc --noEmit -p server/tsconfig.json` and `eslint` on both touched files are clean.

Reverting only `server/gjc-bun-sdk-adapter.ts` makes the new test fail, so it is a real regression test.