### PR TITLE
fix(chat): stop rendering a failed run's error twice

### DIFF
--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -331,7 +331,7 @@ async function handleChatSend(
       : null;
     if (provider === 'gjc' && code) {
       sendProtocolError(ws, code, message, sessionId);
-    } else {
+    } else if (run.status === 'running') {
       run.writer.send(createNormalizedMessage({
         kind: 'error',
         provider,
@@ -339,6 +339,10 @@ async function handleChatSend(
         content: message,
       }));
     }
+    // A run that already passed its terminal `complete` reported the failure
+    // itself (GJC forwards `error` + `complete` before rejecting), so a second
+    // bubble here is the same failure rendered twice in the transcript. The
+    // console line above keeps the rejection visible server-side either way.
   } finally {
     // Safety net: a runtime that crashed (or resolved) without emitting its
     // terminal `complete` would otherwise leave the session stuck in

--- a/server/modules/websocket/tests/chat-websocket.service.test.ts
+++ b/server/modules/websocket/tests/chat-websocket.service.test.ts
@@ -304,6 +304,100 @@ test('chat.send dispatches a non-Git GJC session directly in its persisted proje
   });
 });
 
+test('a runtime that reported its own failure does not get a second error bubble', async () => {
+  await withIsolatedDatabase(async () => {
+    sessionsDb.createAppSession('failing-session', 'gjc', '/workspace/failing-project');
+
+    const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    try {
+      await once(server, 'listening');
+      server.on('connection', (socket, request) => {
+        handleChatConnection(
+          socket,
+          Object.assign(request, { user: { id: 'test-user' } }),
+          {
+            spawnFns: {
+              // This is what the GJC supervisor does on a failed run: forward
+              // the error and the terminal complete, then reject the promise.
+              gjc: (_command, _options, writer) => {
+                const chatWriter = writer as {
+                  send(message: unknown): void;
+                  sendComplete(options: { exitCode: number }): void;
+                };
+                chatWriter.send({
+                  kind: 'error',
+                  provider: 'gjc',
+                  sessionId: 'failing-session',
+                  content: 'GJC worker failed.',
+                });
+                chatWriter.sendComplete({ exitCode: 1 });
+                return Promise.reject(new Error('GJC worker failed.'));
+              },
+            },
+            abortFns: { gjc: async () => false },
+            resolveToolApproval() {},
+            getPendingApprovalsForSession: () => [],
+          },
+        );
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected the websocket test server to bind a TCP port.');
+      }
+
+      const client = new WebSocket(`ws://127.0.0.1:${address.port}`);
+      try {
+        await once(client, 'open');
+        const frames: OutboundFrame[] = [];
+        const completed = new Promise<void>((resolve, reject) => {
+          client.on('message', (raw) => {
+            try {
+              const frame = parseOutboundFrame(String(raw));
+              frames.push(frame);
+              if (frame.kind === 'complete') {
+                resolve();
+              }
+            } catch (error) {
+              reject(error);
+            }
+          });
+        });
+
+        client.send(JSON.stringify({
+          type: 'chat.send',
+          sessionId: 'failing-session',
+          content: 'fail please',
+          options: {},
+        }));
+        await completed;
+        // The rejection is handled after the terminal frame, so give the
+        // catch branch a turn before asserting nothing else arrived.
+        await flushMessages();
+        await flushMessages();
+
+        assert.deepEqual(frames.map((frame) => frame.kind), ['error', 'complete']);
+        assert.equal(frames[0]?.content, 'GJC worker failed.');
+      } finally {
+        client.terminate();
+      }
+    } finally {
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+  });
+});
+
 test('chat.abort uses the direct GJC run handle before the app session id', async () => {
   await withIsolatedDatabase(async () => {
     sessionsDb.createAppSession('abort-session', 'gjc', '/workspace/non-git-project');


### PR DESCRIPTION
## Symptom

Every failed turn shows the same error twice in the chat transcript — two identical `GJC worker failed.` bubbles for a single `chat.send`. Reported by a user as "answers sometimes come out twice"; for failures it is not "sometimes", it is every time.

## Evidence

Frames captured on the app's own websocket for one `chat.send` (desktop 2.0.0-beta.6, one client, one run):

```
04:00:52 chat_subscribed
03:57:42 error    {"content":"GJC worker failed.","id":"error_7748930f-abb6-429d-b8fc-4deb9a954..."}
03:57:42 complete {"exitCode":1}
03:57:42 error    {"content":"GJC worker failed.","id":"error_fee23e76-5816-4f7c-b18b-83f7a8be5..."}
```

Two different message ids, so nothing downstream can dedupe them.

## Cause

`GjcWorkerSupervisor.finish()` (`server/gjc-worker-client.ts`) forwards the failure itself — `createNormalizedMessage({ kind: 'error' })` plus `createCompleteMessage(...)` — and *then* rejects the run promise. `handleChatSend` awaits that promise, catches the rejection, and (no `code` on the plain `Error`) sends another `error` message for the same failure.

## Change

The catch only synthesizes an error message while the run is still `running` — that is the case it exists for: a runtime that died without reporting anything, which would otherwise leave the turn silent. Once the terminal `complete` has passed through `chatRunRegistry` and flipped the run to `completed`, the failure is already rendered, so the second bubble is dropped. The `console.error` in the same branch is untouched, so the rejection is still visible server-side.

## Tests

`server/modules/websocket/tests/chat-websocket.service.test.ts`: new test drives a `gjc` spawn fn that sends `error` + `sendComplete({ exitCode: 1 })` and then rejects, and asserts the client receives exactly `['error', 'complete']`.

`node --test server/modules/websocket/tests/chat-websocket.service.test.ts` → 9 pass / 0 fail. Reverting only `chat-websocket.service.ts` makes the new test fail (`8 pass / 1 fail`), so it is a real regression test. `tsc -p server/tsconfig.json` and `eslint` on both files are clean.

Related: #11 (separate bug, same session — that one is why the runs were failing at all).