### PR TITLE
fix: prevent bypass confirmation dialog jump

### DIFF
--- a/src/components/chat/view/BypassConfirmDialog.tsx
+++ b/src/components/chat/view/BypassConfirmDialog.tsx
@@ -18,7 +18,7 @@ export default function BypassConfirmDialog({ open, onCancel, onConfirm }: Bypas
   const { t } = useTranslation('chat');
   return (
     <Dialog open={open} onOpenChange={(next) => { if (!next) onCancel(); }}>
-      <DialogContent className="max-w-md p-5" data-testid="bypass-confirm">
+      <DialogContent className="max-w-md animate-none p-5" data-testid="bypass-confirm">
         <DialogTitle className="not-sr-only flex items-center gap-2 text-base font-semibold text-destructive">
           <TriangleAlert className="size-4" aria-hidden />
           {t('permissionMode.bypassConfirm.title')}

--- a/src/components/chat/view/PermissionModePicker.dom.bun.test.tsx
+++ b/src/components/chat/view/PermissionModePicker.dom.bun.test.tsx
@@ -58,6 +58,7 @@ test('the first switch to bypass asks for confirmation and only then reports it,
 
   const dialog = await screen.findByRole('dialog');
   assert.match(dialog.textContent ?? '', /run any command without asking/);
+  assert.match(dialog.className, /animate-none/, 'the bypass warning opens at its final centered position');
   assert.deepEqual(updates, [], 'nothing is sent before the user confirms');
 
   fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));


### PR DESCRIPTION
## What this changes

- Disables the shared transform-and-scale entrance animation for the one-time **Bypass** permission confirmation dialog.
- Adds a DOM regression assertion that the dialog uses the static entrance class.

## Why

Selecting **Bypass** could render the confirmation dialog briefly off its final centered position before it snapped into place. The common dialog animation overrides the transform used for centering. This change keeps the safety confirmation at its final center position from its first rendered frame.

### Reproduction

1. Open a project that has not previously acknowledged Bypass mode.
2. Open the permission-mode picker and select **Bypass**.
3. Observe the **Turn off permission prompts?** confirmation dialog.

**Expected:** the dialog appears at its final centered position.

**Actual before this change:** the dialog could begin offset and visibly snap into the center during its entrance animation.

## Scope and impact

- User-visible behavior: only the Bypass confirmation dialog no longer animates its position or scale on open.
- Permission selection, acknowledgement, cancellation, and mode persistence are unchanged.
- No API, migration, compatibility, security, or platform-specific behavior changes.
- No runtime failure path changes; dismissing or confirming the dialog retains its existing behavior.

## Related work

No related issues or pull requests found after searching the upstream repository for `bypass dialog`.

## Verification

- `dist-native/bun test src/components/chat/view/PermissionModePicker.dom.bun.test.tsx` — 5 passed.
- `npm run lint` — passed.
- `npm run build` — passed.
- Manual reproduction in the local macOS development app confirmed the original snap when the shared animation was restored.
- `npm run verify` reached and passed audit, license, notices, typecheck, and Rust-core checks, but the repository-wide Node test run currently fails in nine unrelated client suites because `react-syntax-highlighter@16.1.1` does not export `oneDark` from `react-syntax-highlighter/dist/esm/styles/prism`. This branch does not touch the syntax-highlighter import or its dependency version.

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or I am the project owner.
- [x] `npm run verify` passes, or I have said below which gate fails and why.
