### PR TITLE
fix: clear session on root navigation

### DIFF
--- a/src/hooks/useProjectsState.restore.dom.bun.test.tsx
+++ b/src/hooks/useProjectsState.restore.dom.bun.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, test } from 'node:test';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, cleanup, render, waitFor } from '@testing-library/react';
-import { createElement } from 'react';
+import { createElement, useState } from 'react';
 
 import type { Project } from '../types/app';
 import { resetAppShellStore } from '../stores/useAppShellStore';
@@ -37,10 +37,13 @@ type HookState = ReturnType<typeof useProjectsState>;
 /** One page load: a fresh query cache and shell store, the same localStorage. */
 const mountApp = (route: { sessionId?: string | null } = {}) => {
   let state: HookState | null = null;
+  let setRouteSessionId: ((sessionId: string | null) => void) | null = null;
   const queryClient = new QueryClient({ defaultOptions: { queries: { refetchOnWindowFocus: false, retry: false } } });
   const Harness = () => {
+    const [sessionId, setSessionId] = useState(route.sessionId ?? null);
+    setRouteSessionId = setSessionId;
     state = useProjectsState({
-      sessionId: route.sessionId ?? null,
+      sessionId,
       navigate: (() => undefined) as never,
       subscribe: () => () => undefined,
       isMobile: false,
@@ -53,6 +56,10 @@ const mountApp = (route: { sessionId?: string | null } = {}) => {
     getState: () => {
       assert.ok(state, 'hook state is available after rendering');
       return state;
+    },
+    setRouteSessionId: (sessionId: string | null) => {
+      assert.ok(setRouteSessionId, 'route state is available after rendering');
+      setRouteSessionId(sessionId);
     },
     reload: () => {
       view.unmount();
@@ -138,6 +145,28 @@ test('a session route restores from the URL and leaves the remembered project al
     await waitFor(() => assert.equal(app.getState().projects.length, 2));
     await act(async () => { await Promise.resolve(); });
     assert.equal(app.getState().selectedProject, null, 'the URL owns the context on /session/:id');
+  } finally {
+    restore();
+  }
+});
+
+test('returning to the root route clears a session rehydrated before navigation settled', async () => {
+  const session = { id: 'session-1', summary: 'Existing work' };
+  const projectWithSession = {
+    ...project('project-1', 'Project one'),
+    sessions: [session],
+    sessionMeta: { hasMore: false, total: 1 },
+  };
+  const restore = serveProjects([projectWithSession, twoProjects[1]]);
+  try {
+    const app = mountApp({ sessionId: session.id });
+    await waitFor(() => assert.equal(app.getState().selectedSession?.id, session.id));
+
+    act(() => { app.getState().handleNewSession(projectWithSession); });
+    await waitFor(() => assert.equal(app.getState().selectedSession?.id, session.id));
+
+    act(() => { app.setRouteSessionId(null); });
+    await waitFor(() => assert.equal(app.getState().selectedSession, null));
   } finally {
     restore();
   }

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -229,7 +229,11 @@ export function useProjectsState({ sessionId, navigate, subscribe, isMobile, act
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
   useEffect(() => {
-    if (!sessionId || !projects.length) return;
+    if (!sessionId) {
+      if (selectedSession) setSelectedSession(null);
+      return;
+    }
+    if (!projects.length) return;
     for (const project of projects) {
       const session = rowsOf(project).find((candidate) => candidate.id === sessionId);
       if (!session) continue;
@@ -241,7 +245,7 @@ export function useProjectsState({ sessionId, navigate, subscribe, isMobile, act
     if (selectedSession?.id !== sessionId && selectedProject) {
       setSelectedSession({ id: sessionId, __provider: fallbackProvider, __projectId: selectedProject.projectId, summary: '' });
     }
-  }, [projects, selectedProject, selectedSession?.__provider, selectedSession?.id, sessionId, setSelectedProject, setSelectedSession]);
+  }, [projects, selectedProject, selectedSession, sessionId, setSelectedProject, setSelectedSession]);
 
   const handleProjectSelect = useCallback((project: Project) => {
     setSelectedProject(project);

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -228,9 +228,14 @@ export function useProjectsState({ sessionId, navigate, subscribe, isMobile, act
 
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
 
+  const restoredFromUrlRef = useRef<string | null>(null);
   useEffect(() => {
     if (!sessionId) {
-      if (selectedSession) setSelectedSession(null);
+      // Only a session this effect restored from the URL is stale once the
+      // route settles at '/'; an optimistically registered new-chat session
+      // must survive there until its own /session/:id navigation lands.
+      if (selectedSession && restoredFromUrlRef.current === selectedSession.id) setSelectedSession(null);
+      restoredFromUrlRef.current = null;
       return;
     }
     if (!projects.length) return;
@@ -240,10 +245,12 @@ export function useProjectsState({ sessionId, navigate, subscribe, isMobile, act
       const normalized = withProvider(session);
       if (selectedProject?.projectId !== project.projectId) setSelectedProject(project);
       if (selectedSession?.id !== sessionId || selectedSession.__provider !== normalized.__provider) setSelectedSession(normalized);
+      restoredFromUrlRef.current = sessionId;
       return;
     }
     if (selectedSession?.id !== sessionId && selectedProject) {
       setSelectedSession({ id: sessionId, __provider: fallbackProvider, __projectId: selectedProject.projectId, summary: '' });
+      restoredFromUrlRef.current = sessionId;
     }
   }, [projects, selectedProject, selectedSession, sessionId, setSelectedProject, setSelectedSession]);
 


### PR DESCRIPTION
## What this changes

- Treats the root route (`/`) as an explicit no-session state.
- Clears a stale selected session after the route settles at `/`.
- Adds a DOM regression test for the navigation race between clearing a session and URL-based session restoration.

## Why

Clicking **New work item** from a session could require a second click before the main pane showed a fresh chat. The handler cleared the selected session and navigated to `/`, but the URL-restoration effect could run once with the old `/session/:id` value and restore that session. When the router then reached `/`, the effect returned without clearing the stale selection.

### Reproduction

1. Open an existing session at `/session/<id>`.
2. Click **New work item**.
3. Observe that the previous session can remain selected until clicking **New work item** again.

**Expected:** one click opens the fresh chat for the current project.

**Actual before this change:** the URL restoration race could reselect the previous session after the first click.

## Scope and impact

- User-visible behavior: New work item, browser back navigation, and direct navigation to `/` consistently leave no selected session.
- Session restoration remains URL-driven for `/session/:id` routes.
- No API, migration, compatibility, security, or platform-specific behavior changes.
- No failure or recovery behavior changes beyond removing the stale selected-session state.

## Related work

No related issues or pull requests found after searching the upstream repository for `new work item navigation`.

## Verification

- `dist-native/bun test src/hooks/useProjectsState.restore.dom.bun.test.tsx` — 5 passed.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- Local development server checked after the change: client and API health endpoint both returned HTTP 200.
- `npm run verify` reached and passed audit, license, notices, typecheck, and Rust-core checks, but the repository-wide Node test run currently fails in nine unrelated client suites because `react-syntax-highlighter@16.1.1` does not export `oneDark` from `react-syntax-highlighter/dist/esm/styles/prism`. This branch does not touch the syntax-highlighter import or dependency version.

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or I am the project owner.
- [x] `npm run verify` passes, or I have said below which gate fails and why.
