### PR TITLE
fix: align project path controls

### DIFF
--- a/src/components/project-creation-wizard/components/WorkspacePathField.tsx
+++ b/src/components/project-creation-wizard/components/WorkspacePathField.tsx
@@ -125,6 +125,7 @@ export default function WorkspacePathField({
         <Button
           type="button"
           variant="outline"
+          size="sm"
           onClick={() => setIsFolderBrowserOpen(true)}
           className="px-3"
           title={t('projectWizard.folderBrowser.browseFolders')}


### PR DESCRIPTION
## What this changes

Sets the Add project folder-browser button to the shared small button size (`h-9`) so it matches the adjacent path input's shared `h-9` height.

## Why

The path input used the owned Input primitive at 36px (`h-9`), while its adjacent folder-browser button used Button's default 40px (`h-10`) size. The two controls therefore rendered at visibly different heights.

### Reproduction

1. Open **Add project**.
2. Compare the local path input with the folder icon button immediately to its right.

**Expected:** both controls share a 36px height.

**Actual before this change:** the folder button was 4px taller than the input.

## Scope and impact

- User-visible behavior: the two controls now align vertically at the shared compact control height.
- The shared Input and Button primitives, button defaults, dialog behavior, filesystem browsing, and project creation behavior are unchanged.
- No API, migration, compatibility, security, platform, failure-handling, or recovery behavior changes.

## Related work

No related issues or pull requests found after searching the upstream repository for `add project path height`.

## Verification

- Manual verification in the local development app: the path input and folder-browser button now use the same 36px height.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm run verify` — started and passed audit, license, notices, and TypeScript checks, then stopped before tests because this shell lacks Cargo (`sh: cargo: command not found`). The changed frontend file does not depend on the Rust core; the required Rust toolchain is unavailable in this shell environment.

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or I am the project owner.
- [x] `npm run verify` passes, or I have said below which gate fails and why.
