### PR TITLE
fix: prevent context dialog jump

### DIFF
--- a/src/components/chat/view/CommandResultModal.tsx
+++ b/src/components/chat/view/CommandResultModal.tsx
@@ -528,6 +528,7 @@ export default function CommandResultModal({
   const isOpen = Boolean(payload);
   const kind = payload?.kind;
   const isModelsModal = kind === 'models';
+  const isCostModal = kind === 'cost';
 
   const modalMeta = {
     help: {
@@ -561,7 +562,7 @@ export default function CommandResultModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="flex h-[min(92dvh,48rem)] w-[calc(100vw-1rem)] max-w-5xl flex-col overflow-hidden rounded-3xl border-border/80 bg-popover/95 p-0 shadow-2xl backdrop-blur-xl sm:w-[min(94vw,64rem)]">
+      <DialogContent className={`flex h-[min(92dvh,48rem)] w-[calc(100vw-1rem)] max-w-5xl flex-col overflow-hidden rounded-3xl border-border/80 bg-popover/95 p-0 shadow-2xl backdrop-blur-xl sm:w-[min(94vw,64rem)] ${isCostModal ? 'animate-none' : ''}`}>
         <DialogTitle>{activeMeta?.title || 'Command Result'}</DialogTitle>
 
         <div


### PR DESCRIPTION
## What this changes

Disables the shared transform-and-scale entrance animation only for the **Token Usage** dialog opened from the composer context-usage control.

## Why

The shared dialog animation animates the same `transform` property used to center the dialog. When opening the context-usage popup, its first rendered frame could appear offset toward the upper left before snapping to its final centered position.

### Reproduction

1. Open a session with a reported context window.
2. Click the composer context-usage badge (for example, `Context 42%`).
3. Observe the **Token Usage** dialog opening.

**Expected:** the dialog appears at its final centered position from its first frame.

**Actual before this change:** the dialog could visibly enter from an offset position, then snap to the center.

## Scope and impact

- User-visible behavior: only the Token Usage dialog no longer animates position or scale on open.
- The Help, Models, and Status command-result dialogs retain their existing entrance animation.
- Context usage calculation, token data, dialog actions, and dismissal behavior are unchanged.
- No API, migration, compatibility, security, platform, failure-handling, or recovery behavior changes.

## Related work

No related issues or pull requests found after searching the upstream repository for `context usage dialog`.

## Verification

- `npm run lint` — passed.
- `npm run typecheck` — passed.
- Local development server verified after the change: client and API health endpoint both returned HTTP 200.
- `npm run verify` passed audit, license, notices, TypeScript, Rust-core checks, and 385 tests. It then failed in nine existing client suites because `react-syntax-highlighter@16.1.1` does not export `oneDark` from `react-syntax-highlighter/dist/esm/styles/prism`. This branch does not touch the syntax-highlighter import or dependency version.

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or I am the project owner.
- [x] `npm run verify` passes, or I have said below which gate fails and why.
