### PR TITLE
fix(ui): open every dialog at its centered position

### DIFF
--- a/src/components/chat/view/BypassConfirmDialog.tsx
+++ b/src/components/chat/view/BypassConfirmDialog.tsx
@@ -18,7 +18,7 @@ export default function BypassConfirmDialog({ open, onCancel, onConfirm }: Bypas
   const { t } = useTranslation('chat');
   return (
     <Dialog open={open} onOpenChange={(next) => { if (!next) onCancel(); }}>
-      <DialogContent className="max-w-md animate-none p-5" data-testid="bypass-confirm">
+      <DialogContent className="max-w-md p-5" data-testid="bypass-confirm">
         <DialogTitle className="not-sr-only flex items-center gap-2 text-base font-semibold text-destructive">
           <TriangleAlert className="size-4" aria-hidden />
           {t('permissionMode.bypassConfirm.title')}

--- a/src/components/chat/view/PermissionModePicker.dom.bun.test.tsx
+++ b/src/components/chat/view/PermissionModePicker.dom.bun.test.tsx
@@ -58,7 +58,6 @@ test('the first switch to bypass asks for confirmation and only then reports it,
 
   const dialog = await screen.findByRole('dialog');
   assert.match(dialog.textContent ?? '', /run any command without asking/);
-  assert.match(dialog.className, /animate-none/, 'the bypass warning opens at its final centered position');
   assert.deepEqual(updates, [], 'nothing is sent before the user confirms');
 
   fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/src/index.css
+++ b/src/index.css
@@ -88,15 +88,22 @@
     }
   }
 
+  /*
+   * The panel is centered by the `translate` property (Tailwind 4's
+   * -translate-x-1/2 -translate-y-1/2). The entrance must not touch
+   * translate, in either `transform` or `translate`: a keyframe translate
+   * composes with the utility's and the panel opens offset toward the
+   * upper left, snapping to center when the animation ends.
+   */
   @keyframes dialog-content-show {
     from {
       opacity: 0;
-      transform: translate(-50%, -48%) scale(0.96);
+      transform: scale(0.96);
     }
 
     to {
       opacity: 1;
-      transform: translate(-50%, -50%) scale(1);
+      transform: scale(1);
     }
   }
 }

--- a/src/shared/view/ui/Dialog.dom.bun.test.tsx
+++ b/src/shared/view/ui/Dialog.dom.bun.test.tsx
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+
+import { cleanup, render, screen } from '@testing-library/react';
+
+import { Dialog, DialogContent, DialogTitle } from './Dialog';
+
+/*
+ * Tailwind 4 centers the panel with the `translate` property, not
+ * `transform`. An entrance keyframe that translates - in either property -
+ * composes with the centering, so the panel opens offset toward the upper
+ * left and snaps to center when the animation ends. Three dialogs had
+ * papered over that with `animate-none` before the keyframe was fixed; this
+ * pins the contract at the primitive so no dialog needs to opt out again.
+ */
+
+afterEach(cleanup);
+
+const stylesheet = readFileSync(path.resolve(import.meta.dirname, '../../../index.css'), 'utf8');
+
+const keyframeBlock = (name: string): string => {
+  const start = stylesheet.indexOf(`@keyframes ${name}`);
+  assert.notEqual(start, -1, `${name} is defined in src/index.css`);
+  let depth = 0;
+  for (let index = stylesheet.indexOf('{', start); index < stylesheet.length; index += 1) {
+    if (stylesheet[index] === '{') depth += 1;
+    if (stylesheet[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return stylesheet.slice(start, index + 1);
+    }
+  }
+  throw new Error(`${name} block is not closed`);
+};
+
+test('the panel is centered by the translate utilities and animated by the keyframe alone', () => {
+  render(
+    <Dialog open onOpenChange={() => {}}>
+      <DialogContent>
+        <DialogTitle>Centered</DialogTitle>
+        body
+      </DialogContent>
+    </Dialog>
+  );
+  const panel = screen.getByRole('dialog');
+  const classes = panel.className.split(/\s+/);
+  for (const expected of ['fixed', 'top-1/2', 'left-1/2', '-translate-x-1/2', '-translate-y-1/2', 'animate-dialog-content-show']) {
+    assert.ok(classes.includes(expected), `${expected} on the panel`);
+  }
+  assert.ok(!classes.includes('animate-none'), 'the primitive does not opt out of its own entrance');
+});
+
+test('the entrance keyframe never translates, so it cannot fight the centering', () => {
+  const block = keyframeBlock('dialog-content-show');
+  assert.doesNotMatch(block, /translate/, 'no translate() or translate: in dialog-content-show');
+  assert.match(block, /transform:\s*scale\(/, 'the entrance is a scale');
+  assert.match(block, /opacity:\s*0/, 'the entrance fades in');
+});
+
+test('no dialog opts out of the entrance with animate-none', () => {
+  const src = path.resolve(import.meta.dirname, '../../..');
+  const offenders = readdirSync(src, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.(tsx?|jsx?|css)$/.test(entry.name))
+    .map((entry) => path.join(entry.parentPath, entry.name))
+    .filter((file) => file !== import.meta.filename && readFileSync(file, 'utf8').includes('animate-none'))
+    .map((file) => path.relative(src, file));
+  assert.deepEqual(offenders, [], 'animate-none is a band-aid over the primitive; fix the keyframe instead');
+});


### PR DESCRIPTION
## What this changes

Fixes the dialog entrance at the primitive instead of per dialog.

Tailwind 4 centers `DialogContent` with the `translate` property (`-translate-x-1/2 -translate-y-1/2` compile to `translate: var(--tw-translate-x) var(--tw-translate-y)`), while `@keyframes dialog-content-show` still animated `transform: translate(-50%, -48%) scale(0.96)` from the Tailwind 3 days. The two compose, so for the 150 ms entrance every dialog sat a full panel width/height toward the upper left and snapped to center when the animation ended - the "jump" #25 and #29 each patched with `animate-none` on one dialog.

- `src/index.css`: the keyframe now fades and scales only; it never touches translate in either property.
- `BypassConfirmDialog.tsx`: the `animate-none` opt-out from #25 is removed; the dialog gets its entrance back, centered.
- `src/shared/view/ui/Dialog.dom.bun.test.tsx` (new): the panel carries the centering utilities and the entrance class; the keyframe contains no `translate`; no file under `src/` uses `animate-none`. Red on `main` (two failures), green here.

Supersedes #29: the token-usage dialog opens centered without an opt-out.

## Verification

- `dist-native/bun test src/shared/view/ui/Dialog.dom.bun.test.tsx src/components/chat/view/PermissionModePicker.dom.bun.test.tsx` - 8 pass
- `npm run typecheck`, eslint on the touched files
- Tailwind 4.3.3 output confirmed: `.-translate-x-1/2 { translate: var(--tw-translate-x) var(--tw-translate-y) }`
