### PR TITLE
feat(chat): read every edit mode's diff from the runtime's result

### DIFF
--- a/docs/V2-SESSION-HANDOFF.md
+++ b/docs/V2-SESSION-HANDOFF.md
@@ -498,11 +498,17 @@ after the reconcile fetch replaces realtime timestamps with disk ones.
      Terra session's second turn went to GLM and hit its rate limit. An
      explicit model on the first turn is now the session pin
      (`resolveResumeModel(..., { firstTurn })`); `default` pins nothing.
-   - Gap, not fixed: with ChatGPT models the runtime edits through
-     `apply_patch`, which neither the Last-turn scope (edit/write/delete/
-     move only) nor the tool card configs know; the scope shows nothing for
-     those turns (Working tree still does) and the card shows raw
-     Parameters/Details. Needs a patch parser or a runtime-side normalization.
+   - ~~Gap, not fixed: with ChatGPT models the runtime edits through
+     `apply_patch`, which neither the Last-turn scope nor the tool card
+     configs know~~ — **closed 2026-09-05 (#33)** without a patch parser:
+     the runtime's edit *result* details (`{path, op, move, diff}` per file,
+     `perFileResults[]` for an envelope, numbered diff `+12|text`) are the
+     normalization every edit mode shares, and they already reach the client
+     as `toolResult.toolUseResult` live and on reload.
+     `src/components/chat/utils/editResult.ts` reads them; the edit card
+     (`apply_patch` shares it) and the Last-turn scope render from the
+     result, with real line numbers, and fall back to the replace-mode input
+     only while a call runs or when a result carries no details.
    - Upstream: with the ChatGPT provider the model received the project
      path as `/Users/USER/…` and passed it back as the bash `cwd`, which
      does not exist; the run recovered via `pwd`. The runtime redacts the

--- a/server/tool-configs-contract.bun.test.ts
+++ b/server/tool-configs-contract.bun.test.ts
@@ -33,6 +33,7 @@ const NON_RUNTIME_KEYS: Readonly<Record<string, string>> = {
   AskUserQuestion: 'The label gjc-sdk-bridge.ts gives a question; the worker sends `ask`.',
   exit_plan_mode: 'Plan-mode payload rendered inline by PlanDisplay, not a builtin tool.',
   ExitPlanMode: 'Legacy casing of the same plan-mode payload.',
+  apply_patch: 'The wire name the edit tool takes in apply_patch mode (its customWireName); the same config as edit.',
 };
 
 test('every configured tool name is one the runtime actually sends', () => {
@@ -69,6 +70,21 @@ test('the tools most calls go through have a config rather than the JSON fallbac
 
 test('the question config is shared, not duplicated', () => {
   assert.equal(TOOL_CONFIGS.ask, TOOL_CONFIGS.AskUserQuestion);
+});
+
+/*
+ * `edit` exposes itself to the GPT-5 family as `apply_patch` (EditTool's
+ * `customWireName`), and that is the name a call arrives under. The card must
+ * be the edit card, and the exemption above must keep describing a name the
+ * runtime really uses - if the runtime ever registers it as a tool of its own,
+ * the exemption test fails and the key gets checked like the rest.
+ */
+test('apply_patch is the edit tool under its wire name', async () => {
+  const { EditTool } = await import('@gajae-code/coding-agent/edit');
+  assert.equal(TOOL_CONFIGS.apply_patch, TOOL_CONFIGS.edit);
+  const wireName = Object.getOwnPropertyDescriptor(EditTool.prototype, 'customWireName');
+  assert.ok(wireName?.get, 'EditTool declares a customWireName getter');
+  assert.match(String(wireName.get), /apply_patch/, 'the wire name is apply_patch');
 });
 
 /**

--- a/src/components/chat/tools/ToolRenderer.editResult.test.tsx
+++ b/src/components/chat/tools/ToolRenderer.editResult.test.tsx
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ToolRenderer } from './ToolRenderer';
+
+/*
+ * An apply_patch call (the edit tool under its GPT-5 wire name) used to render
+ * as raw Parameters: its input is an envelope with no path, and the edit card
+ * only knew the replace-mode input. The card now reads the runtime's result
+ * details, which every edit mode reports the same way.
+ */
+
+const createDiff = (oldStr: string, newStr: string) => [
+  ...oldStr.split('\n').map((content) => ({ type: 'removed', content, lineNum: 0 })),
+  ...newStr.split('\n').map((content) => ({ type: 'added', content, lineNum: 0 })),
+];
+
+const details = {
+  diff: '+1|hello\n-3|gone',
+  perFileResults: [
+    { path: 'src/new.ts', diff: '+1|hello', op: 'create' },
+    { path: 'src/from.ts', diff: '-3|gone', op: 'update', move: 'src/to.ts' },
+  ],
+};
+
+const render = (toolName: string, toolInput: unknown, toolResult: unknown) => renderToStaticMarkup(createElement(ToolRenderer, {
+  toolName,
+  toolInput,
+  toolResult,
+  toolId: 'call-1',
+  mode: 'input',
+  createDiff,
+  density: 'detailed',
+}));
+
+test('an apply_patch call renders one diff per file the runtime reports, titled by the count', () => {
+  const html = render('apply_patch', { input: '*** Begin Patch\n*** Add File: src/new.ts\n+hello\n*** End Patch' }, { content: 'ok', isError: false, toolUseResult: details });
+
+  assert.match(html, /2 files/);
+  assert.match(html, /data-testid="edit-result-diffs"/);
+  assert.match(html, /src\/new\.ts[\s\S]*?>New</);
+  assert.match(html, /src\/to\.ts[\s\S]*?>Renamed</);
+  assert.match(html, /hello/);
+  assert.match(html, /gone/);
+  assert.doesNotMatch(html, /Begin Patch/, 'the envelope is not dumped as parameters');
+  assert.match(html, /data-testid="diff-stats"[\s\S]*?\+1[\s\S]*?−1/, 'the folded row still counts the runtime diff');
+});
+
+test('a replace-mode edit with details shows the runtime diff, and without them the input pair', () => {
+  const input = { path: 'src/a.ts', edits: [{ old_text: 'x = 1', new_text: 'x = 2' }] };
+  const withDetails = render('edit', input, { content: 'ok', isError: false, toolUseResult: { path: '/repo/src/a.ts', diff: ' 4|before\n-5|x = 1\n+5|x = 2' } });
+  assert.match(withDetails, /data-testid="edit-result-diffs"/);
+  assert.match(withDetails, /before/, 'context the runtime kept is shown');
+
+  const running = render('edit', input, undefined);
+  assert.doesNotMatch(running, /data-testid="edit-result-diffs"/);
+  assert.match(running, /x = 1[\s\S]*x = 2/, 'the proposed replacement is shown while the call runs');
+});

--- a/src/components/chat/tools/ToolRenderer.tsx
+++ b/src/components/chat/tools/ToolRenderer.tsx
@@ -33,12 +33,33 @@ function resultText(result: any): string {
   return result?.content != null ? String(result.content) : '';
 }
 
-function titleFrom(config: any, value: unknown, fallback: string): string {
-  return typeof config.title === 'function' ? config.title(value) : config.title || fallback;
+function titleFrom(config: any, value: unknown, fallback: string, helpers?: unknown): string {
+  return typeof config.title === 'function' ? config.title(value, helpers) : config.title || fallback;
+}
+
+const editBadge: Record<string, string> = { create: 'New', delete: 'Deleted', update: 'Diff' };
+
+/** One viewer per file the runtime reports it edited, whichever edit mode ran. */
+function EditResultDiffs({ files, onFileOpen }: { files: Array<{ path: string; op: string; move: string | null; lines: DiffLine[] }>; onFileOpen?: (filePath: string) => void }): React.ReactNode {
+  return (
+    <div className="space-y-2" data-testid="edit-result-diffs">
+      {files.map((file, index) => (
+        <ToolDiffViewer
+          key={`${file.path}:${index}`}
+          filePath={file.path}
+          lines={file.lines}
+          badge={file.move ? 'Renamed' : editBadge[file.op] ?? 'Diff'}
+          badgeColor={file.op === 'create' ? 'green' : 'gray'}
+          onFileClick={onFileOpen && file.op !== 'delete' ? () => onFileOpen(file.path) : undefined}
+        />
+      ))}
+    </div>
+  );
 }
 
 function CollapsibleBody({ contentType, contentProps, createDiff, onFileOpen, config, data }: any): React.ReactNode {
   if (contentType === 'diff') {
+    if (contentProps.files) return <EditResultDiffs files={contentProps.files} onFileOpen={onFileOpen} />;
     return createDiff ? <ToolDiffViewer {...contentProps} createDiff={createDiff} onFileClick={() => onFileOpen?.(contentProps.filePath)} /> : null;
   }
   if (contentType === 'markdown') return <MarkdownContent content={contentProps.content || ''} />;
@@ -55,9 +76,9 @@ function CollapsibleBody({ contentType, contentProps, createDiff, onFileOpen, co
 }
 
 /** The +N/-M a folded diff row carries, so a closed edit still says how big it was. */
-function DiffStats({ createDiff, oldContent, newContent }: { createDiff?: (oldStr: string, newStr: string) => DiffLine[]; oldContent?: string; newContent?: string }): React.ReactNode {
-  if (!createDiff || oldContent === undefined || newContent === undefined) return null;
-  const lines = createDiff(oldContent, newContent);
+function DiffStats({ createDiff, oldContent, newContent, files }: { createDiff?: (oldStr: string, newStr: string) => DiffLine[]; oldContent?: string; newContent?: string; files?: Array<{ lines: DiffLine[] }> }): React.ReactNode {
+  const lines = files ? files.flatMap((file) => file.lines) : createDiff && oldContent !== undefined && newContent !== undefined ? createDiff(oldContent, newContent) : null;
+  if (!lines) return null;
   const added = lines.filter((line) => line.type === 'added').length;
   const removed = lines.filter((line) => line.type === 'removed').length;
   return (
@@ -101,19 +122,20 @@ export const ToolRenderer: React.FC<ToolRendererProps> = ({ toolName, toolInput,
     return <OneLineDisplay toolName={toolName} icon={displayConfig.icon} label={displayConfig.label} value={value} secondary={secondary} action={displayConfig.action} onAction={handleAction} style={displayConfig.style} wrapText={displayConfig.wrapText} colorScheme={displayConfig.colorScheme} status={toolStatus !== 'completed' ? toolStatus : undefined} />;
   }
 
-  const contentProps = displayConfig.getContentProps?.(parsedData, { selectedProject, createDiff, onFileOpen }) || {};
+  const helpers = { selectedProject, createDiff, onFileOpen, toolResult };
+  const contentProps = displayConfig.getContentProps?.(parsedData, helpers) || {};
   if (displayConfig.type === 'plan') {
-    return <PlanDisplay title={titleFrom(displayConfig, parsedData, 'Plan')} content={contentProps.content || ''} defaultOpen={collapsibleStartsOpen(rules, displayConfig.defaultOpen ?? false)} isStreaming={mode === 'input' && !toolResult} showRawParameters={mode === 'input' && showRawParameters} rawContent={rawToolInput} toolName={toolName} toolId={toolId} />;
+    return <PlanDisplay title={titleFrom(displayConfig, parsedData, 'Plan', helpers)} content={contentProps.content || ''} defaultOpen={collapsibleStartsOpen(rules, displayConfig.defaultOpen ?? false)} isStreaming={mode === 'input' && !toolResult} showRawParameters={mode === 'input' && showRawParameters} rawContent={rawToolInput} toolName={toolName} toolId={toolId} />;
   }
   if (displayConfig.type !== 'collapsible') return null;
 
   const isDiff = displayConfig.contentType === 'diff';
-  const canOpenFile = (toolName === 'Edit' || toolName === 'Write' || toolName === 'ApplyPatch') && contentProps.filePath && onFileOpen;
+  const canOpenFile = ['edit', 'write', 'apply_patch', 'Edit', 'Write', 'ApplyPatch'].includes(toolName) && contentProps.filePath && onFileOpen;
   const onTitleClick = canOpenFile ? () => onFileOpen(contentProps.filePath, { old_string: contentProps.oldContent, new_string: contentProps.newContent }) : undefined;
   const badge = toolStatus && toolStatus !== 'completed' ? <ToolStatusBadge status={toolStatus} /> : undefined;
   const startsOpen = isDiff ? rules.diffOpen : collapsibleStartsOpen(rules, displayConfig.defaultOpen);
-  const action = isDiff ? <DiffStats createDiff={createDiff} oldContent={contentProps.oldContent} newContent={contentProps.newContent} /> : undefined;
-  return <CollapsibleDisplay toolName={toolName} toolId={toolId} title={titleFrom(displayConfig, parsedData, 'Details')} defaultOpen={startsOpen} onTitleClick={onTitleClick} badge={badge} action={action} showRawParameters={mode === 'input' && showRawParameters} rawContent={rawToolInput}><CollapsibleBody contentType={displayConfig.contentType} contentProps={contentProps} createDiff={createDiff} onFileOpen={onFileOpen} config={displayConfig} data={parsedData} /></CollapsibleDisplay>;
+  const action = isDiff ? <DiffStats createDiff={createDiff} oldContent={contentProps.oldContent} newContent={contentProps.newContent} files={contentProps.files} /> : undefined;
+  return <CollapsibleDisplay toolName={toolName} toolId={toolId} title={titleFrom(displayConfig, parsedData, 'Details', helpers)} defaultOpen={startsOpen} onTitleClick={onTitleClick} badge={badge} action={action} showRawParameters={mode === 'input' && showRawParameters} rawContent={rawToolInput}><CollapsibleBody contentType={displayConfig.contentType} contentProps={contentProps} createDiff={createDiff} onFileOpen={onFileOpen} config={displayConfig} data={parsedData} /></CollapsibleDisplay>;
 };
 
 ToolRenderer.displayName = 'ToolRenderer';

--- a/src/components/chat/tools/components/ToolDiffViewer.tsx
+++ b/src/components/chat/tools/components/ToolDiffViewer.tsx
@@ -2,15 +2,17 @@ import React, { useMemo } from 'react';
 
 type DiffLine = { type: string; content: string; lineNum: number };
 
-interface ToolDiffViewerProps {
-  oldContent: string;
-  newContent: string;
+type ToolDiffViewerProps = {
   filePath: string;
-  createDiff: (oldStr: string, newStr: string) => DiffLine[];
   onFileClick?: () => void;
   badge?: string;
   badgeColor?: 'gray' | 'green';
-}
+} & (
+  // Two sources: a before/after pair the client diffs itself, or the rows the
+  // runtime reported it applied (every edit mode, with real line numbers).
+  | { oldContent: string; newContent: string; createDiff: (oldStr: string, newStr: string) => DiffLine[]; lines?: undefined }
+  | { lines: DiffLine[]; oldContent?: undefined; newContent?: undefined; createDiff?: undefined }
+);
 
 function diffAppearance(type: string) {
   if (type === 'removed') return { className: 'bg-diff-removed text-diff-removed-foreground', marker: '-' };
@@ -39,14 +41,16 @@ export const ToolDiffViewer: React.FC<ToolDiffViewerProps> = ({
   newContent,
   filePath,
   createDiff,
+  lines: givenLines,
   onFileClick,
   badge = 'Diff',
   badgeColor = 'gray',
 }) => {
   const lines = useMemo(() => {
-    if (oldContent === undefined || newContent === undefined) return [];
+    if (givenLines) return givenLines;
+    if (!createDiff || oldContent === undefined || newContent === undefined) return [];
     return createDiff(oldContent, newContent);
-  }, [createDiff, oldContent, newContent]);
+  }, [createDiff, givenLines, oldContent, newContent]);
   const badgeClasses = badgeColor === 'green' ? 'bg-diff-added text-diff-added-foreground' : 'bg-muted text-muted-foreground';
   const fileLabel = onFileClick ? (
     <button onClick={onFileClick} className="cursor-pointer truncate font-mono text-xs text-muted-foreground transition-colors hover:text-primary">

--- a/src/components/chat/tools/configs/toolConfigs.test.ts
+++ b/src/components/chat/tools/configs/toolConfigs.test.ts
@@ -142,3 +142,37 @@ test('the tools that only had a JSON dump now say what they were asked for', () 
   // Unregistered tools still fall back rather than crash.
   assert.equal(getToolConfig('no_such_tool'), TOOL_CONFIGS.Default);
 });
+
+/*
+ * The edit tool has five modes with five input shapes, and apply_patch (the
+ * GPT-5 family) arrives under its own wire name with a multi-file envelope
+ * and no path. The card reads the runtime's result details, which every mode
+ * reports the same way, and keeps the replace-mode input as its fallback.
+ */
+test('an edit with runtime details renders the diff the runtime applied, per file', () => {
+  const details = {
+    diff: '+1|hello\n-3|gone',
+    perFileResults: [
+      { path: 'new.ts', diff: '+1|hello', op: 'create' },
+      { path: 'from.ts', diff: '@@ -3,1 +3,0 @@\n-3|gone', op: 'update', move: 'to.ts' },
+    ],
+  };
+  const props = TOOL_CONFIGS.apply_patch.input.getContentProps?.({ input: '*** Begin Patch\n*** End Patch' }, { toolResult: { toolUseResult: details } });
+
+  assert.equal(TOOL_CONFIGS.apply_patch, TOOL_CONFIGS.edit, 'apply_patch is the edit card under its wire name');
+  assert.equal(props.filePath, 'new.ts');
+  assert.deepEqual(props.files.map((file: { path: string; op: string; move: string | null }) => [file.path, file.op, file.move]), [['new.ts', 'create', null], ['to.ts', 'update', 'to.ts']]);
+  assert.deepEqual(props.files[0].lines, [{ type: 'added', content: 'hello', lineNum: 1 }]);
+  assert.deepEqual(props.files[1].lines, [{ type: 'removed', content: 'gone', lineNum: 3 }], 'hunk headers are not rows');
+  assert.equal(titleOf('apply_patch', { input: '' }), 'Edit', 'no result yet: nothing to name');
+  assert.equal(TOOL_CONFIGS.edit.input.title && typeof TOOL_CONFIGS.edit.input.title === 'function' ? TOOL_CONFIGS.edit.input.title({ input: '' }, { toolResult: { toolUseResult: details } }) : '', '2 files');
+  assert.equal(TOOL_CONFIGS.edit.input.title && typeof TOOL_CONFIGS.edit.input.title === 'function' ? TOOL_CONFIGS.edit.input.title({ input: '' }, { toolResult: { toolUseResult: { path: '/repo/src/one.ts', diff: '' } } }) : '', 'one.ts');
+});
+
+test('an edit whose result carries no details keeps the replace-mode fallback', () => {
+  const input = { path: 'src/a.ts', edits: [{ old_text: 'x', new_text: 'y' }] };
+  const props = TOOL_CONFIGS.edit.input.getContentProps?.(input, { toolResult: { content: 'ok' } });
+  assert.equal(props.files, undefined);
+  assert.equal(props.oldContent, 'x');
+  assert.equal(titleOf('edit', input), 'a.ts', 'the input path names the card whatever the result says');
+});

--- a/src/components/chat/tools/configs/toolConfigs.ts
+++ b/src/components/chat/tools/configs/toolConfigs.ts
@@ -1,9 +1,11 @@
+import { editResultFiles, parseRuntimeDiff } from '../../utils/editResult.js';
+
 export interface ToolDisplayConfig {
   input: {
     type: 'one-line' | 'collapsible' | 'plan' | 'hidden';
     icon?: string; label?: string; getValue?: (input: any) => string; getSecondary?: (input: any) => string | undefined; action?: 'copy' | 'open-file' | 'jump-to-results' | 'none'; style?: string; wrapText?: boolean;
     colorScheme?: { primary?: string; secondary?: string; background?: string; border?: string; icon?: string };
-    title?: string | ((input: any) => string); defaultOpen?: boolean; contentType?: 'diff' | 'markdown' | 'file-list' | 'todo-list' | 'text' | 'task' | 'question-answer'; getContentProps?: (input: any, helpers?: any) => any; actionButton?: 'file-button' | 'none';
+    title?: string | ((input: any, helpers?: any) => string); defaultOpen?: boolean; contentType?: 'diff' | 'markdown' | 'file-list' | 'todo-list' | 'text' | 'task' | 'question-answer'; getContentProps?: (input: any, helpers?: any) => any; actionButton?: 'file-button' | 'none';
   };
   result?: { hidden?: boolean; hideOnSuccess?: boolean; type?: 'one-line' | 'collapsible' | 'plan' | 'special'; title?: string | ((result: any) => string); defaultOpen?: boolean; contentType?: 'markdown' | 'file-list' | 'todo-list' | 'text' | 'success-message' | 'task' | 'question-answer'; getMessage?: (result: any) => string; getContentProps?: (result: any) => any };
 }
@@ -58,6 +60,33 @@ function computerSummary(input: unknown): string {
   return [action.action, detail].filter(Boolean).join(' ');
 }
 
+/**
+ * An edit card's diff. The runtime's result details carry the numbered diff it
+ * applied, one record per file, for every edit mode (replace, patch, hashline,
+ * vim, apply_patch); the replace-mode input is the fallback while the call
+ * is still running or when a result carries no details.
+ */
+function editContent(input: any, helpers?: { toolResult?: { toolUseResult?: unknown } }) {
+  const edits = Array.isArray(input.edits) ? input.edits : [];
+  const files = editResultFiles(helpers?.toolResult?.toolUseResult, typeof input.path === 'string' ? input.path : '')
+    .map((file) => ({ path: file.move ?? file.path, op: file.op, move: file.move, lines: parseRuntimeDiff(file.diff).flatMap((row) => (row.kind === 'hunk' ? [] : [{ type: row.kind, content: row.content, lineNum: row.newLine ?? row.oldLine ?? 0 }])) }));
+  return {
+    filePath: input.path || files[0]?.path || '',
+    oldContent: edits.map((edit: any) => String(edit?.old_text ?? '')).join('\n'),
+    newContent: edits.map((edit: any) => String(edit?.new_text ?? '')).join('\n'),
+    files: files.length > 0 ? files : undefined,
+  };
+}
+
+function editTitle(input: any, helpers?: { toolResult?: { toolUseResult?: unknown } }): string {
+  if (input.path) return leafName(input);
+  const files = editResultFiles(helpers?.toolResult?.toolUseResult);
+  if (files.length > 1) return `${files.length} files`;
+  return files[0] ? leafName({ path: files[0].move ?? files[0].path }) : 'Edit';
+}
+
+const editConfig: ToolDisplayConfig = { input: { type: 'collapsible', title: editTitle, defaultOpen: false, contentType: 'diff', actionButton: 'file-button', getContentProps: editContent }, result: { hideOnSuccess: true } };
+
 const outputAsCode = (result: any) => ({ content: String(result?.content || ''), format: 'code' });
 const outputAsText = (result: any) => ({ content: String(result?.content || ''), format: 'plain' });
 const leafName = (input: any) => input.path?.split('/').pop() || input.path || 'file';
@@ -90,7 +119,10 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
   ast_grep: callOnly('AST Grep', (input) => input.pat || ''),
   skill: { input: { type: 'one-line', label: 'Skill', getValue: (input) => input.name ? `/skill:${input.name}` : '', getSecondary: (input) => input.args || undefined, action: 'none', colorScheme: skillColors } },
   todo_write: { input: { type: 'collapsible', title: (input) => todoTitle(input.ops), defaultOpen: false, contentType: 'markdown', getContentProps: (input) => ({ content: todoMarkdown(input.ops) }) }, result: { hideOnSuccess: true } },
-  edit: { input: { type: 'collapsible', title: leafName, defaultOpen: false, contentType: 'diff', actionButton: 'file-button', getContentProps: (input) => { const edits = Array.isArray(input.edits) ? input.edits : []; return { filePath: input.path || '', oldContent: edits.map((edit: any) => String(edit?.old_text ?? '')).join('\n'), newContent: edits.map((edit: any) => String(edit?.new_text ?? '')).join('\n') }; } }, result: { hideOnSuccess: true } },
+  edit: editConfig,
+  // The edit tool's wire name in apply_patch mode (GPT-5 family): the input is
+  // a multi-file envelope, the result the same per-file details as every mode.
+  apply_patch: editConfig,
   lsp: callOnly('LSP', (input) => [input.action, input.symbol || input.query || input.file].filter(Boolean).join(' ')),
   web_search: { input: { type: 'one-line', label: 'Web Search', getValue: (input) => input.query || '', getSecondary: (input) => input.recency ? `past ${input.recency}` : undefined, action: 'none', colorScheme: neutralColors } },
   computer: callOnly('Computer', computerSummary),

--- a/src/components/chat/utils/editResult.test.ts
+++ b/src/components/chat/utils/editResult.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { editResultFiles, parseRuntimeDiff } from './editResult';
+
+/*
+ * The runtime's edit result is the one shape every edit mode shares:
+ * `{ path, op, move, diff }` for one file, `perFileResults[]` for an
+ * apply_patch envelope, and a numbered diff (`+12|text`) either way.
+ */
+
+test('a single-file result is one file with the fallback path when the details carry none', () => {
+  assert.deepEqual(editResultFiles({ diff: '+1|a', path: '/repo/a.ts' }), [
+    { path: '/repo/a.ts', op: 'update', move: null, diff: '+1|a', isError: false },
+  ]);
+  assert.deepEqual(editResultFiles({ diff: '+1|a', firstChangedLine: 1 }, 'src/b.ts').map((file) => file.path), ['src/b.ts']);
+  assert.deepEqual(editResultFiles({ diff: '+1|a' }), [], 'no path anywhere: nothing to show');
+});
+
+test('a multi-file apply_patch result keeps the order and the per-file operation', () => {
+  const files = editResultFiles({
+    diff: '+1|a\n-3|old',
+    perFileResults: [
+      { path: 'a.ts', diff: '+1|a', op: 'create' },
+      { path: 'b.ts', diff: '-3|old', op: 'update', move: 'c.ts' },
+      { path: 'd.ts', diff: '', op: 'delete' },
+      { path: 'e.ts', diff: '', isError: true, errorText: 'no such file' },
+    ],
+  });
+  assert.deepEqual(files.map((file) => [file.path, file.op, file.move, file.isError]), [
+    ['a.ts', 'create', null, false],
+    ['b.ts', 'update', 'c.ts', false],
+    ['d.ts', 'delete', null, false],
+    ['e.ts', 'update', null, true],
+  ]);
+});
+
+test('details that are not a record yield nothing', () => {
+  for (const details of [undefined, null, 'text', 42, [], { perFileResults: 'nope', path: '' }]) {
+    assert.deepEqual(editResultFiles(details), [], String(details));
+  }
+});
+
+test('replace-mode numbered diff: added rows know the new line, removed the old, context both', () => {
+  const rows = parseRuntimeDiff([
+    ' 1|import a',
+    ' 2|',
+    '-3|const x = 1;',
+    '+3|const x = 2;',
+    '+4|const y = 3;',
+    ' 4|export { x };',
+    ' 5|...',
+    ' 12|tail',
+  ].join('\n'));
+  assert.deepEqual(rows, [
+    { kind: 'context', content: 'import a', oldLine: 1, newLine: 1 },
+    { kind: 'context', content: '', oldLine: 2, newLine: 2 },
+    { kind: 'removed', content: 'const x = 1;', oldLine: 3, newLine: null },
+    { kind: 'added', content: 'const x = 2;', oldLine: null, newLine: 3 },
+    { kind: 'added', content: 'const y = 3;', oldLine: null, newLine: 4 },
+    { kind: 'context', content: 'export { x };', oldLine: 4, newLine: 5 },
+    { kind: 'context', content: '...', oldLine: 5, newLine: 6 },
+    { kind: 'context', content: 'tail', oldLine: 12, newLine: 13 },
+  ]);
+});
+
+test('patch-mode hunks reset the new-line offset from the header and become separators', () => {
+  const rows = parseRuntimeDiff([
+    '@@ -1,2 +1,1 @@',
+    '-1|a',
+    ' 2|b',
+    '@@ -10,2 +9,3 @@',
+    ' 10|c',
+    '+10|d',
+    ' 11|e',
+    'stray line without a number',
+  ].join('\n'));
+  assert.deepEqual(rows, [
+    { kind: 'hunk', content: '@@ -1,2 +1,1 @@' },
+    { kind: 'removed', content: 'a', oldLine: 1, newLine: null },
+    { kind: 'context', content: 'b', oldLine: 2, newLine: 1 },
+    { kind: 'hunk', content: '@@ -10,2 +9,3 @@' },
+    { kind: 'context', content: 'c', oldLine: 10, newLine: 9 },
+    { kind: 'added', content: 'd', oldLine: null, newLine: 10 },
+    { kind: 'context', content: 'e', oldLine: 11, newLine: 11 },
+  ]);
+});
+
+test('a line whose content contains a pipe keeps everything after the first one', () => {
+  assert.deepEqual(parseRuntimeDiff('+7|a || b'), [{ kind: 'added', content: 'a || b', oldLine: null, newLine: 7 }]);
+  assert.deepEqual(parseRuntimeDiff(''), []);
+});

--- a/src/components/chat/utils/editResult.ts
+++ b/src/components/chat/utils/editResult.ts
@@ -1,0 +1,91 @@
+import type { UnifiedDiffRow } from '../../workspace/utils/unifiedDiff.js';
+
+/*
+ * The runtime's `edit` tool has several modes (replace, patch, hashline, vim,
+ * apply_patch - the last one under its own wire name), and each mode has its
+ * own input shape. What every mode agrees on is the *result*: the runtime's
+ * typed details carry the file's path, the operation, a rename target and a
+ * numbered diff of what it actually applied - one record for a single file,
+ * `perFileResults[]` for a multi-file apply_patch envelope. The app reads
+ * that, so a card or the Changes tab never has to know which mode ran.
+ *
+ * Details reach the client as `toolResult.toolUseResult`, live and reloaded
+ * alike (gjc-bun-sdk-events.ts, gjc-sessions.provider.ts).
+ */
+
+export type EditResultOp = 'create' | 'update' | 'delete';
+
+export type EditResultFile = {
+  path: string;
+  op: EditResultOp;
+  /** New path after a rename, when the edit moved the file. */
+  move: string | null;
+  /** The runtime's numbered diff (`+12|text`, `-5|text`, ` 7|text`), possibly empty. */
+  diff: string;
+  isError: boolean;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const text = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+function fileFrom(record: Record<string, unknown>, fallbackPath: string): EditResultFile | null {
+  const path = text(record.path) || fallbackPath;
+  if (!path) return null;
+  const op = record.op === 'create' || record.op === 'delete' ? record.op : 'update';
+  return { path, op, move: text(record.move) || null, diff: text(record.diff), isError: record.isError === true };
+}
+
+/**
+ * The files an edit result touched, in the order the runtime applied them.
+ * Empty when the result carries no runtime details (a failed call, a foreign
+ * transcript), in which case the caller falls back to the call's input.
+ */
+export function editResultFiles(details: unknown, fallbackPath = ''): EditResultFile[] {
+  if (!isRecord(details)) return [];
+  if (Array.isArray(details.perFileResults)) {
+    return details.perFileResults.flatMap((entry) => (isRecord(entry) ? fileFrom(entry, '') ?? [] : []));
+  }
+  const single = fileFrom(details, fallbackPath);
+  return single ? [single] : [];
+}
+
+const NUMBERED_LINE = /^([+\- ])(\d+)\|(.*)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/**
+ * The runtime's numbered diff as rows with real line numbers: an added row
+ * knows its line in the new file, a removed row its line in the old one, so
+ * a comment on it lands as `path:line` like a working-tree diff. The runtime
+ * numbers context rows by the old file; their new-file line follows from the
+ * adds and removes before them (and the hunk header, in patch mode). Hunk
+ * headers become separators; replace mode's ` N|...` elisions advance both
+ * files equally and stay the context rows they print as.
+ */
+export function parseRuntimeDiff(diff: string): UnifiedDiffRow[] {
+  const rows: UnifiedDiffRow[] = [];
+  let delta = 0; // new line - old line for the next context row
+  for (const line of diff.split('\n')) {
+    const hunk = HUNK_HEADER.exec(line);
+    if (hunk) {
+      delta = Number(hunk[2]) - Number(hunk[1]);
+      rows.push({ kind: 'hunk', content: line });
+      continue;
+    }
+    const match = NUMBERED_LINE.exec(line);
+    if (!match) continue;
+    const [, prefix, number, content] = match;
+    const lineNumber = Number(number);
+    if (prefix === '+') {
+      rows.push({ kind: 'added', content, oldLine: null, newLine: lineNumber });
+      delta += 1;
+    } else if (prefix === '-') {
+      rows.push({ kind: 'removed', content, oldLine: lineNumber, newLine: null });
+      delta -= 1;
+    } else {
+      rows.push({ kind: 'context', content, oldLine: lineNumber, newLine: lineNumber + delta });
+    }
+  }
+  return rows;
+}

--- a/src/components/workspace/hooks/useLastTurnChanges.test.ts
+++ b/src/components/workspace/hooks/useLastTurnChanges.test.ts
@@ -134,3 +134,77 @@ test('charges separator rows to the shared output-row budget', () => {
   assert.equal(file.rows, null);
   assert.equal(file.tooLarge, true);
 });
+
+/*
+ * The runtime's result details are the source of truth for every edit mode.
+ * A replace-mode call gets real line numbers from them; an apply_patch
+ * envelope (GPT-5 family), whose input names no path, gets its files from
+ * them; a result without details falls back to the replace-mode input.
+ */
+test('an edit with runtime details takes its rows, with line numbers, from the result', () => {
+  const [file] = lastTurnFiles([
+    message({ kind: 'text', role: 'user', content: 'Edit' }),
+    message({
+      toolName: 'edit',
+      toolInput: { path: 'src/a.ts', edits: [{ old_text: 'x = 1', new_text: 'x = 2' }] },
+      toolResult: { content: 'ok', isError: false, toolUseResult: { path: '/repo/src/a.ts', diff: ' 4|before\n-5|x = 1\n+5|x = 2\n 6|after', firstChangedLine: 5 } },
+    }),
+  ]);
+  assert.deepEqual([file.path, file.kind, file.oldPath, file.tooLarge], ['/repo/src/a.ts', 'edit', null, false]);
+  assert.deepEqual(file.rows?.map((row) => [row.kind, row.content, row.kind === 'hunk' ? null : row.oldLine, row.kind === 'hunk' ? null : row.newLine]), [
+    ['context', 'before', 4, 4],
+    ['removed', 'x = 1', 5, null],
+    ['added', 'x = 2', null, 5],
+    ['context', 'after', 6, 6],
+  ]);
+});
+
+test('an apply_patch envelope lists every file its result reports, by operation', () => {
+  const files = lastTurnFiles([
+    message({ kind: 'text', role: 'user', content: 'Patch' }),
+    message({
+      toolName: 'apply_patch',
+      toolId: 'patch-1',
+      toolInput: { input: '*** Begin Patch\n*** Add File: new.ts\n+hello\n*** End Patch' },
+    }),
+    message({
+      kind: 'tool_result',
+      toolId: 'patch-1',
+      content: 'ok',
+      isError: false,
+      isFinal: true,
+      ...({ toolUseResult: { diff: '+1|hello', perFileResults: [
+        { path: 'new.ts', diff: '+1|hello', op: 'create' },
+        { path: 'old.ts', diff: '-3|gone', op: 'update' },
+        { path: 'from.ts', diff: '', op: 'update', move: 'to.ts' },
+        { path: 'dead.ts', diff: '', op: 'delete' },
+        { path: 'broken.ts', diff: '', isError: true, errorText: 'context not found' },
+      ] } } as object),
+    }),
+  ]);
+  assert.deepEqual(files.map((file) => [file.path, file.kind, file.oldPath, file.rows?.length ?? null]), [
+    ['new.ts', 'write', null, 1],
+    ['old.ts', 'edit', null, 1],
+    ['to.ts', 'move', 'from.ts', null],
+    ['dead.ts', 'delete', null, null],
+  ]);
+  assert.deepEqual(files[0].rows, [{ kind: 'added', content: 'hello', oldLine: null, newLine: 1 }]);
+});
+
+test('an apply_patch call is a pending mutation until its result lands, and nothing without details', () => {
+  const pending = [
+    message({ kind: 'text', role: 'user', content: 'Patch' }),
+    message({ toolName: 'apply_patch', toolId: 'patch-2', toolInput: { input: '*** Begin Patch\n*** End Patch' } }),
+  ];
+  assert.equal(hasPendingLastTurnMutation(pending), true);
+  assert.deepEqual(lastTurnFiles([...pending, message({ kind: 'tool_result', toolId: 'patch-2', content: 'ok', isError: false, isFinal: true })]), []);
+});
+
+test('a result diff above the budget marks the file too large instead of rendering it', () => {
+  const diff = Array.from({ length: 2500 }, (_, index) => `+${index + 1}|line`).join('\n');
+  const [file] = lastTurnFiles([
+    message({ kind: 'text', role: 'user', content: 'Big' }),
+    message({ toolName: 'edit', toolInput: { path: 'big.ts', edits: [] }, toolResult: { content: 'ok', isError: false, toolUseResult: { path: 'big.ts', diff } } }),
+  ]);
+  assert.deepEqual([file.rows, file.tooLarge], [null, true]);
+});

--- a/src/components/workspace/hooks/useLastTurnChanges.ts
+++ b/src/components/workspace/hooks/useLastTurnChanges.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 
+import { editResultFiles, parseRuntimeDiff, type EditResultFile } from '../../chat/utils/editResult';
 import { createCachedDiffCalculator } from '../../chat/utils/messageTransforms';
 import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
 import type { UnifiedDiffRow } from '../utils/unifiedDiff';
@@ -39,9 +40,14 @@ function pathValue(value: unknown): string | null {
   return typeof value === 'string' && value ? value : null;
 }
 
+// `apply_patch` is the edit tool's wire name in its apply_patch mode (GPT-5
+// family models); its input is a multi-file envelope, and its result the same
+// per-file details every other edit mode reports.
+const EDIT_TOOLS = ['edit', 'apply_patch'];
+
 function isMutationTool(message: NormalizedMessage): boolean {
   if (message.kind !== 'tool_use' || !message.toolName) return false;
-  return ['edit', 'write', 'delete', 'move'].includes(message.toolName.toLowerCase());
+  return [...EDIT_TOOLS, 'write', 'delete', 'move'].includes(message.toolName.toLowerCase());
 }
 
 export function hasPendingLastTurnMutation(messages: NormalizedMessage[]): boolean {
@@ -98,6 +104,23 @@ function editRows(edits: unknown, budget: DiffBudget): UnifiedDiffRow[] | null {
   return rows;
 }
 
+/**
+ * A file from the runtime's own edit result. Rows come from the numbered diff
+ * it applied, with real line numbers, regardless of which edit mode ran.
+ */
+function editResultFile(file: EditResultFile, budget: DiffBudget): LastTurnFile | null {
+  if (file.isError) return null;
+  if (file.move) return { path: file.move, kind: 'move', oldPath: file.path, rows: null, tooLarge: false };
+  if (file.op === 'delete') return { path: file.path, kind: 'delete', oldPath: null, rows: null, tooLarge: false };
+  const kind = file.op === 'create' ? 'write' : 'edit';
+  if (file.diff.length > budget.characters) return { path: file.path, kind, oldPath: null, rows: null, tooLarge: true };
+  const rows = parseRuntimeDiff(file.diff);
+  if (rows.length > budget.rows) return { path: file.path, kind, oldPath: null, rows: null, tooLarge: true };
+  budget.characters -= file.diff.length;
+  budget.rows -= rows.length;
+  return { path: file.path, kind, oldPath: null, rows, tooLarge: false };
+}
+
 export function lastTurnFiles(messages: NormalizedMessage[]): LastTurnFile[] {
   const lastUser = messages.reduce((last, message, index) =>
     message.kind === 'text' && message.role === 'user' ? index : last, -1);
@@ -116,12 +139,22 @@ export function lastTurnFiles(messages: NormalizedMessage[]): LastTurnFile[] {
   return turn.flatMap((message): LastTurnFile[] => {
     if (message.kind !== 'tool_use' || !message.toolName) return [];
     const kind = message.toolName.toLowerCase();
-    if (kind !== 'edit' && kind !== 'write' && kind !== 'delete' && kind !== 'move') return [];
+    if (!EDIT_TOOLS.includes(kind) && kind !== 'write' && kind !== 'delete' && kind !== 'move') return [];
 
     const input = parseToolInput(message.toolInput);
     if (!input) return [];
     const result = message.toolResult ?? (message.toolId ? results.get(message.toolId) : null);
     if (!result || result.isError === true || ('isFinal' in result && result.isFinal === false)) return [];
+
+    if (EDIT_TOOLS.includes(kind)) {
+      // The runtime's result is the source of truth for every edit mode; the
+      // replace-mode input is the fallback for a result that carries none.
+      // A standalone tool_result row carries the runtime details at its top
+      // level, the same slot a merged `toolResult` does.
+      const fromResult = editResultFiles((result as { toolUseResult?: unknown }).toolUseResult, pathValue(input.path) ?? '');
+      if (fromResult.length > 0) return fromResult.flatMap((file) => editResultFile(file, budget) ?? []);
+    }
+    if (kind !== 'edit' && kind !== 'write' && kind !== 'delete' && kind !== 'move') return [];
 
     if (kind === 'move') {
       const oldPath = pathValue(input.from) ?? pathValue(input.path);


### PR DESCRIPTION
## What this changes

Closes the handoff's "apply_patch gap": with ChatGPT/GPT-5 models the runtime edits through `apply_patch` (the edit tool's `customWireName`, a multi-file envelope with no `path`), which neither the edit card nor the Changes tab's Last-turn scope understood - the card showed raw Parameters, the scope showed nothing.

Instead of a patch parser, the app reads what every edit mode (replace, patch, hashline, vim, apply_patch) reports the same way: the runtime's result details - `{ path, op, move, diff }` per file, `perFileResults[]` for an envelope, with a numbered diff (`+12|text`) of what was actually applied. Those details already reach the client as `toolResult.toolUseResult` on the live path and on reload (verified against a real transcript: `details.diff` = `" 1|...\n 87|  opacity: 1;\n+91|  /*..."`).

- `src/components/chat/utils/editResult.ts` (new): `editResultFiles(details)` and `parseRuntimeDiff(diff)` → rows with real old/new line numbers (context rows are numbered by the old file; the new line follows from adds/removes and the hunk header).
- Edit card: `apply_patch` shares the edit config; body and title come from the result when present (one viewer per file, badges New / Renamed / Deleted / Diff, `+N −M` from the runtime rows), the replace-mode input while running or without details. `ToolDiffViewer` accepts precomputed rows.
- Last-turn scope: `edit` and `apply_patch` files come from the result (create → write, delete, move, update → edit) with line numbers, so a review comment lands as `path:line` like a working-tree diff. Input fallback kept for results without details.
- `server/tool-configs-contract.bun.test.ts`: `apply_patch` documented as the edit tool's wire name and asserted against `EditTool.customWireName`.

## Verification

- `editResult.test.ts` 6, `useLastTurnChanges.test.ts` 11 (4 new), `toolConfigs.test.ts` 10 (2 new), `ToolRenderer.editResult.test.tsx` 2 (new), `tool-configs-contract.bun.test.ts` 7 (1 new), `WorkspaceChangesTab.dom.bun.test.tsx` 6 - all green; typecheck + eslint.
- `npm run verify` running before merge.
