### PR TITLE
fix: preserve provider model variants

### DIFF
--- a/server/gjc-bun-sdk-adapter.ts
+++ b/server/gjc-bun-sdk-adapter.ts
@@ -390,12 +390,7 @@ export class GjcBunSdkAdapter implements GjcWorkerRuntime {
     const models = [];
     const candidates = await modelsForCredential(this.authStorage, this.modelRegistry, { kind: 'stored' });
 
-    const selections = this.modelRegistry.getCanonicalModelSelections({
-      availableOnly: true,
-      candidates,
-    });
-    for (const { record, model } of selections) {
-      if (!model) continue;
+    for (const model of candidates) {
       const value = `${model.provider}/${model.id}`;
       if (seen.has(value)) continue;
       seen.add(value);
@@ -404,11 +399,12 @@ export class GjcBunSdkAdapter implements GjcWorkerRuntime {
         efforts = getSupportedEfforts(model);
       }
       const defaultEffort = MODEL_ID_EFFORT.exec(model.id)?.[1];
+      const canonicalId = this.modelRegistry.getCanonicalId(model);
       models.push({
         value,
-        label: record.name || model.name || model.id,
+        label: model.name || model.id,
         group: model.provider,
-        canonicalId: record.id,
+        ...(canonicalId ? { canonicalId } : {}),
         effort: {
           ...(defaultEffort ? { default: defaultEffort } : {}),
           values: efforts.map((effort) => ({ value: effort })),

--- a/server/gjc-sdk-contract.bun.test.ts
+++ b/server/gjc-sdk-contract.bun.test.ts
@@ -260,6 +260,7 @@ async function fixture(
     authStorage,
     getAll: () => models,
     getAvailable: () => models,
+    getCanonicalId: (model: typeof models[number]) => model.id,
     getCanonicalModelSelections: (query: { candidates?: typeof models } = {}) =>
       (query.candidates ?? models).map((model) => ({
         record: {
@@ -688,6 +689,30 @@ test('model catalog reports the runtime-supported reasoning levels', async () =>
         }],
       },
     });
+  } finally {
+    await f.close();
+  }
+});
+
+test('model catalog preserves credentialed provider-qualified models with the same bare id', async () => {
+  const f = await fixture(
+    'cliproxy/gpt-5.6-terra',
+    undefined,
+    [
+      { id: 'gpt-5.6-terra', name: 'CLiProxy Terra', provider: 'cliproxy', reasoning: true, thinking: { minLevel: 'low', maxLevel: 'high', levels: ['low', 'high'], mode: 'effort' } },
+      { id: 'gpt-5.6-terra', name: 'ChatGPT Terra', provider: 'openai-codex', reasoning: true, thinking: { minLevel: 'medium', maxLevel: 'xhigh', levels: ['medium', 'xhigh'], mode: 'effort' } },
+      { id: 'gpt-5.6-terra', name: 'Unavailable Terra', provider: 'other-provider' },
+    ] as never,
+  );
+  try {
+    f.authStorage.credentials.push({ id: 1, provider: 'cliproxy' }, { id: 2, provider: 'openai-codex' });
+    await f.host.handle(request('models.catalog', 'distinct-provider-models'));
+    const payload = response(f.frames, 'distinct-provider-models').payload as { result: { models: Array<{ value: string; label: string; group: string; effort: { values: Array<{ value: string }> } }> } };
+
+    assert.deepEqual(payload.result.models, [
+      { value: 'cliproxy/gpt-5.6-terra', label: 'CLiProxy Terra', group: 'cliproxy', canonicalId: 'gpt-5.6-terra', effort: { values: [{ value: 'low' }, { value: 'high' }] } },
+      { value: 'openai-codex/gpt-5.6-terra', label: 'ChatGPT Terra', group: 'openai-codex', canonicalId: 'gpt-5.6-terra', effort: { values: [{ value: 'medium' }, { value: 'xhigh' }] } },
+    ]);
   } finally {
     await f.close();
   }

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -16,7 +16,7 @@ import type {
 import { readProviderSessionActiveModelChange, writeProviderSessionActiveModelChange } from '@/shared/utils.js';
 
 export const PROVIDER_MODELS_CACHE_TTL_MS = 3 * 24 * 60 * 60 * 1000;
-const PROVIDER_MODELS_CACHE_VERSION = 11;
+const PROVIDER_MODELS_CACHE_VERSION = 12;
 
 type ProviderModelsServiceDependencies = { resolveProvider?: (provider: LLMProvider) => Pick<IProvider, 'models'>; cachePath?: string; activeModelChangesPath?: string; now?: () => number };
 type ProviderModelsOptions = { bypassCache?: boolean };

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -193,6 +193,45 @@ test('provider model cache is persisted across service instances', async () => {
     const models = await reader.getProviderModels('gjc');
     assert.equal(models.models.DEFAULT, 'gjc-cached');
     assert.equal(models.cache.source, 'disk');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('provider model cache ignores the prior catalog schema version', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-version-'));
+  const cachePath = path.join(tempRoot, 'models-cache.json');
+  let loads = 0;
+
+  try {
+    await writeFile(cachePath, JSON.stringify({
+      version: 11,
+      entries: {
+        gjc: {
+          updatedAt: Date.now(),
+          expiresAt: Date.now() + PROVIDER_MODELS_CACHE_TTL_MS,
+          models: createModels('canonical-collapsed'),
+        },
+      },
+    }), 'utf8');
+    const service = createProviderModelsService({
+      cachePath,
+      resolveProvider: () => ({
+        models: {
+          getSupportedModels: async () => {
+            loads += 1;
+            return createModels('provider-qualified');
+          },
+          getCurrentActiveModel: async () => createCurrentActiveModel('gjc-active'),
+          changeActiveModel: async (input) => createSessionActiveModelChange('gjc', input),
+        },
+      }),
+    });
+
+    const result = await service.getProviderModels('gjc');
+    assert.equal(loads, 1);
+    assert.equal(result.models.DEFAULT, 'provider-qualified');
+    assert.equal(result.cache.source, 'fresh');
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What this changes

- Returns every credential-eligible, provider-qualified GJC model from the runtime catalog instead of one canonical-model winner.
- Retains each concrete model's label, provider group, and reasoning-effort metadata.
- Invalidates the persisted provider-model cache so deployments do not keep serving the old canonical-collapsed catalog for up to three days.

## Why

The catalog path used `getCanonicalModelSelections()`, which intentionally selects one representative for models sharing a canonical/bare model id. That is incorrect for distinct transports that happen to use the same model id.

For example, a configured and usable `cliproxy/gpt-5.6-terra` profile could be omitted when `openai-codex/gpt-5.6-terra` won canonical selection. The app then marked the CLiProxy entry unavailable even though the GJC TUI could run it.

### Reproduction

1. Configure separate credentialed providers with the same bare model id, such as `cliproxy/gpt-5.6-terra` and `openai-codex/gpt-5.6-terra`.
2. Reference the CLiProxy model in a GJC model profile.
3. Open the app's Model and reasoning picker.

**Expected:** each provider-qualified model remains independently available and selectable under its provider group.

**Actual before this change:** canonical selection returned only one provider variant, leaving the other profile entry disabled.

## Scope and impact

- User-visible behavior: provider-qualified models with a shared bare id are independently listed and enabled when their own provider credentials are available.
- Trigger labels remain human-readable model labels; provider-qualified values remain internal selection identifiers.
- Explicit provider-qualified selection behavior is unchanged and continues to prefer the exact provider/model match.
- No API shape, migration, security, transport, or model-resolution fallback behavior changes.
- The provider-model cache format version advances once so old collapsed catalogs are discarded.

## Related work

No related issues or pull requests found after searching the upstream repository for `provider model variants`.

## Verification

- `dist-native/bun test server/gjc-sdk-contract.bun.test.ts server/modules/providers/tests/provider-models.service.test.ts` — 85 passed, 1 skipped.
- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run build:server` — passed.
- Manual API verification against the local runtime confirmed `cliproxy/gpt-5.6-luna`, `cliproxy/gpt-5.6-sol`, `cliproxy/gpt-5.6-terra`, and `cliproxy/kimi-k3` are returned as concrete catalog entries.
- `npm run verify` passed audit, license, notices, TypeScript, Rust-core checks, and 385 tests. It then failed in nine existing client suites because `react-syntax-highlighter@16.1.1` does not export `oneDark` from `react-syntax-highlighter/dist/esm/styles/prism`. This branch does not touch the syntax-highlighter import or dependency version.

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or I am the project owner.
- [x] `npm run verify` passes, or I have said below which gate fails and why.
