### PR TITLE
fix(ui): prevent model picker loading layout shifts

### DIFF
--- a/src/components/chat/tests/chatComposerJobModeRemoval.test.tsx
+++ b/src/components/chat/tests/chatComposerJobModeRemoval.test.tsx
@@ -312,3 +312,19 @@ test('the composer tools row wraps instead of clipping its trailing controls', (
   assert.doesNotMatch(toolsRow, /overflow-hidden/);
   assert.match(toolsRow, /flex-wrap/);
 });
+
+test('model controls remain present and disabled while the catalog is missing', () => {
+  for (const loading of [true, false]) {
+    const html = renderToStaticMarkup(createElement(ChatComposer, {
+      ...baseComposerProps,
+      modelPresetOptions: [],
+      modelOptions: [],
+      modelPresetsLoading: loading,
+    }));
+    assert.match(html, /<button[^>]*disabled=""[^>]*aria-label="input\.modelReasoning\.label"/);
+    assert.match(html, /<button[^>]*disabled=""[^>]*aria-label="input\.agentConfiguration\.label"/);
+    assert.match(html, new RegExp(`aria-busy="${loading}"`));
+    assert.match(html, /aria-label="input\.skills\.label"/);
+    assert.doesNotMatch(html, /aria-label="permissionMode\.label"/, 'unavailable permissions must not invent an Ask policy');
+  }
+});

--- a/src/components/chat/view/ChatComposer.tsx
+++ b/src/components/chat/view/ChatComposer.tsx
@@ -131,7 +131,7 @@ interface ChatComposerProps {
   onSelectModelPreset?: (value: string) => Promise<unknown> | unknown;
   reasoningEffort?: ReasoningEffort;
   onSelectReasoningEffort?: (value: ReasoningEffort) => void;
-  /** The selected project's permission policy; null hides the picker. */
+  /** The selected project's permission policy; null reserves its toolbar slot. */
   permissions?: ProjectPermissions | null;
   onSelectPermissionMode?: (update: PermissionModeUpdate) => Promise<unknown> | unknown;
   permissionsBusy?: boolean;
@@ -429,15 +429,17 @@ export default function ChatComposer({
             />
         </PromptInputBody>
 
-        <PromptInputFooter>
+        <PromptInputFooter className="flex-wrap gap-y-1">
           {/*
             Wraps rather than clips. This row carries attach, voice, two model
             controls, skills and context usage; `overflow-hidden` meant a narrow
             viewport silently cut the trailing ones off with nothing to show
             that they existed. Wrapping costs a second line on narrow screens
-            and keeps every control reachable.
+            and keeps every control reachable. Keep metadata-dependent slots
+            mounted so loading cannot reposition the controls; the action group
+            can wrap separately when a split pane leaves too little room.
           */}
-          <PromptInputTools className="min-w-0 flex-wrap gap-y-1">
+          <PromptInputTools className="min-w-32 flex-1 basis-0 flex-wrap gap-y-1">
 
             <PromptInputButton
               tooltip={{ content: t('input.attachImages') }}
@@ -451,38 +453,35 @@ export default function ChatComposer({
               <VoiceInputButton state={voiceState} onToggle={voiceToggle} errorMsg={voiceError} />
             )}
 
-            {modelPresetOptions.length > 0 && (
-              <ModelAndReasoningPicker
-                value={modelPreset}
-                currentModel={displayedModel}
-                presetOptions={modelPresetOptions}
-                modelOptions={modelOptions}
-                availabilityKnown={availabilityKnown}
-                loading={modelPresetsLoading}
-                onSelect={onSelectModelPreset}
-                reasoningEffort={reasoningEffort}
-                onSelectReasoningEffort={onSelectReasoningEffort}
-              />
-            )}
+            <ModelAndReasoningPicker
+              value={modelPreset}
+              currentModel={displayedModel}
+              presetOptions={modelPresetOptions}
+              modelOptions={modelOptions}
+              availabilityKnown={availabilityKnown}
+              loading={modelPresetsLoading}
+              onSelect={onSelectModelPreset}
+              reasoningEffort={reasoningEffort}
+              onSelectReasoningEffort={onSelectReasoningEffort}
+            />
 
-            {modelPresetOptions.length > 0 && (
-              <AgentConfigurationPicker
-                value={modelPreset}
-                options={modelPresetOptions}
-                loading={modelPresetsLoading}
-                openTrigger={modelPickerOpenTrigger}
-                iconOnly
-                onSelect={onSelectModelPreset}
-              />
-            )}
+            <AgentConfigurationPicker
+              value={modelPreset}
+              options={modelPresetOptions}
+              loading={modelPresetsLoading}
+              openTrigger={modelPickerOpenTrigger}
+              iconOnly
+              onSelect={onSelectModelPreset}
+            />
 
-            {permissions && (
+            {permissions ? (
               <PermissionModePicker
                 permissions={permissions}
                 onSelectMode={onSelectPermissionMode}
                 busy={permissionsBusy}
+                className="w-28 shrink-0"
               />
-            )}
+            ) : <div className="h-8 w-28 shrink-0" aria-hidden />}
 
             <SkillPicker
               skills={skillCommands}
@@ -493,7 +492,7 @@ export default function ChatComposer({
 
           </PromptInputTools>
 
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
             {(canQueueDraft || sendByCtrlEnter) && (
               <div
                 className={`hidden text-xs text-muted-foreground/50 transition-opacity duration-200 lg:block ${

--- a/src/components/chat/view/ModelAndReasoningPicker.tsx
+++ b/src/components/chat/view/ModelAndReasoningPicker.tsx
@@ -324,23 +324,26 @@ export default function ModelAndReasoningPicker({
   };
 
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={rootRef} className="relative w-40 max-w-full shrink-0 sm:w-56">
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
         disabled={loading || selecting || groups.length === 0}
-        className="flex h-8 max-w-40 min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50 sm:max-w-56"
+        className="flex h-8 w-full min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
         aria-label={t('input.modelReasoning.label')}
+        aria-busy={loading || selecting}
         aria-expanded={open}
         title={`${displayModel ?? t('input.modelReasoning.defaultModel')} · ${reasoningLabel}`}
       >
-        {(loading || selecting) && <Loader2 className="size-3 animate-spin" />}
-        <span className="min-w-0 truncate">
-          {displayModelLabel ?? t('input.modelReasoning.defaultModel')}
+        {(loading || selecting) && <Loader2 className="size-3 shrink-0 animate-spin" aria-hidden />}
+        <span className="min-w-0 flex-1 truncate text-left">
+          {loading && !displayModelLabel ? (
+            <span className="block h-3 w-full max-w-24 rounded bg-muted" aria-hidden />
+          ) : displayModelLabel ?? t('input.modelReasoning.defaultModel')}
         </span>
         <span className="shrink-0 text-border" aria-hidden>·</span>
         <span className="shrink-0">{reasoningLabel}</span>
-        <ChevronDown className={cn('size-3 transition-transform', open && 'rotate-180')} />
+        <ChevronDown className={cn('size-3 shrink-0 transition-transform', open && 'rotate-180')} aria-hidden />
       </button>
 
       {open && createPortal(

--- a/src/components/chat/view/PermissionModePicker.tsx
+++ b/src/components/chat/view/PermissionModePicker.tsx
@@ -20,6 +20,7 @@ type PermissionModePickerProps = {
   onSelectMode: (update: PermissionModeUpdate) => Promise<unknown> | unknown;
   busy?: boolean;
   disabled?: boolean;
+  className?: string;
 };
 
 /**
@@ -30,7 +31,7 @@ type PermissionModePickerProps = {
  * first time a project switches to it, put behind a confirmation dialog: it is
  * the one setting here that removes a safety net rather than tuning one.
  */
-export default function PermissionModePicker({ permissions, onSelectMode, busy = false, disabled = false }: PermissionModePickerProps) {
+export default function PermissionModePicker({ permissions, onSelectMode, busy = false, disabled = false, className }: PermissionModePickerProps) {
   const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
   const [confirmingBypass, setConfirmingBypass] = useState(false);
@@ -127,14 +128,14 @@ export default function PermissionModePicker({ permissions, onSelectMode, busy =
   const label = t(`permissionMode.modes.${mode}.label`);
 
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={rootRef} className={cn('relative', className)}>
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
         disabled={unavailable || isBusy}
         data-mode={mode}
         className={cn(
-          'flex h-8 max-w-40 min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-50',
+          'flex h-8 w-full max-w-40 min-w-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-50',
           mode === 'bypass' ? 'text-destructive hover:text-destructive' : 'text-muted-foreground hover:text-foreground',
         )}
         aria-label={t('permissionMode.label')}
@@ -143,7 +144,7 @@ export default function PermissionModePicker({ permissions, onSelectMode, busy =
         title={t('permissionMode.tooltip', { mode: label, shortcut })}
       >
         {isBusy ? <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden /> : <Icon className="size-3.5 shrink-0" aria-hidden />}
-        <span className="min-w-0 truncate">{label}</span>
+        <span className="min-w-0 flex-1 truncate text-left">{label}</span>
         <ChevronDown className={cn('size-3 shrink-0 transition-transform', open && 'rotate-180')} aria-hidden />
       </button>
 


### PR DESCRIPTION
## What this changes

Keep the composer model controls in place during initial loading, refresh and model-name changes. The model and agent buttons render from the first frame, and loading uses the same model slot with a disabled skeleton. The permission control reserves its own width without displaying an invented policy before its response arrives.

Model text is truncated within a fixed preferred width, constrained by the available toolbar space. The action group wraps independently in very narrow workspace panes so Send, Stop and queue controls remain reachable. The existing toolbar order is preserved.

## Why

An empty catalog previously removed the model and agent buttons entirely. When data arrived, later controls moved; a longer model name moved them again. The comparison fixture measured approximately 236px of initial movement and another 106px between short and long model labels.

This addresses loading layout, independently of the provider-variant catalog change in #35.

## Verification

- `npm run verify` — passed.
- Linux Node 22/24 CI — passed on `3c48ce6` (run 33973138434).
- Focused composer/model/locale suites — 29 passed.
- Permission picker DOM suite — 9 passed.
- Real browser: 64 combinations of loading/short/long/unavailable catalogs, idle/running controls, mobile widths 320/360/390px, desktop width 1280px and workspace panes down to 200px. Zero position drift across catalog states, overlap or out-of-pane controls.
- Model popup and Extra high selection verified at 320px; full model IDs remain available in the title/popup.

---

- [x] I am the project owner.
- [x] `npm run verify` passes.
