### PR TITLE
fix: preserve desktop settings and validate beta.9 artifacts

### DIFF
--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Set up pinned Node.js
@@ -37,8 +38,12 @@ jobs:
 
       - name: Check build host and define canonical assets
         id: metadata
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          echo "Desktop source commit: $SOURCE_SHA" >> "$GITHUB_STEP_SUMMARY"
           test "$(uname -s)" = Linux
           test "$(uname -m)" = x86_64
           test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.35"
@@ -137,6 +142,7 @@ jobs:
       - name: Checkout smoke harness
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Set up Node.js for the smoke harness

--- a/.github/workflows/server-linux.yml
+++ b/.github/workflows/server-linux.yml
@@ -1,0 +1,285 @@
+name: Linux server archive
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'Exact 40-character source commit (empty uses the dispatched commit)'
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - '.github/workflows/server-linux.yml'
+      - '.github/workflows/ci.yml'
+      - 'src/**'
+      - 'server/**'
+      - 'shared/**'
+      - 'native/**'
+      - 'scripts/**'
+      - 'public/**'
+      - 'packaging/systemd/**'
+      - 'docker/**'
+      - 'package*.json'
+      - '*config*'
+      - '.npmrc'
+      - 'index.html'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'docs/SELF-HOST.md'
+      - 'docs/INSTALL.md'
+      - 'docs/SERVER-LINUX-ACCEPTANCE.md'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/server-linux.yml'
+      - '.github/workflows/ci.yml'
+      - 'src/**'
+      - 'server/**'
+      - 'shared/**'
+      - 'native/**'
+      - 'scripts/**'
+      - 'public/**'
+      - 'packaging/systemd/**'
+      - 'docker/**'
+      - 'package*.json'
+      - '*config*'
+      - '.npmrc'
+      - 'index.html'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'docs/SELF-HOST.md'
+      - 'docs/INSTALL.md'
+      - 'docs/SERVER-LINUX-ACCEPTANCE.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: server-linux-${{ github.workflow }}-${{ inputs.source_sha || github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+# Acceptance/build artifacts only. Source verification is the separate CI gate.
+# No release environment, signing/provider credentials, publication or dispatch.
+jobs:
+  build:
+    name: Build Linux x64 Node 22 archive (glibc 2.35)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha || github.event.pull_request.head.sha || github.sha }}
+    outputs:
+      source_sha: ${{ steps.metadata.outputs.source_sha }}
+      asset_name: ${{ steps.metadata.outputs.asset_name }}
+    steps:
+      - name: Require an immutable source commit
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.22.2'
+          architecture: x64
+          cache: npm
+
+      - name: Check source and build host
+        id: metadata
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(uname -s)" = Linux
+          test "$(uname -m)" = x86_64
+          test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.35"
+          test "$(node --version)" = v22.22.2
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "asset_name=gajae-app-server-${VERSION}-linux-x64-node22.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)" >> "$GITHUB_ENV"
+
+      - name: Install native build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y build-essential python3 pkg-config libssl-dev binutils git ca-certificates
+
+      - name: Set up Rust
+        run: |
+          set -euo pipefail
+          rustup toolchain install 1.85.1 --profile minimal
+          rustup default 1.85.1
+          rustup target add x86_64-unknown-linux-gnu
+
+      - name: Seed verified ripgrep install cache
+        run: node scripts/release/prime-ripgrep-cache.mjs
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch and check pinned Bun runtime
+        run: |
+          set -euo pipefail
+          node scripts/fetch-bun.mjs
+          test "$(dist-native/bun --version)" = 1.4.0
+
+      - name: Check smoke harness regressions
+        run: node --test scripts/release/packaged-server-paths.test.mjs scripts/release/server-archive-smoke.test.mjs
+
+      - name: Build canonical server archive
+        run: npm run server:bundle
+
+      - name: Verify canonical assets and record source provenance
+        env:
+          ASSET_NAME: ${{ steps.metadata.outputs.asset_name }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          git diff --exit-code
+          shopt -s nullglob dotglob
+          assets=(release/server/*)
+          test "${#assets[@]}" -eq 2
+          test -f "release/server/$ASSET_NAME"
+          test -f "release/server/$ASSET_NAME.sha256"
+          (cd release/server && sha256sum --check "$ASSET_NAME.sha256")
+          mkdir -p "$RUNNER_TEMP/server-acceptance"
+          node --input-type=module <<'NODE'
+          import { readFileSync, writeFileSync } from 'node:fs';
+          import path from 'node:path';
+          const asset = process.env.ASSET_NAME;
+          const sha256 = readFileSync(`release/server/${asset}.sha256`, 'utf8').split(/\s+/)[0];
+          const evidence = { sourceSha: process.env.SOURCE_SHA, asset, sha256, node: process.versions.node, glibc: process.report.getReport().header.glibcVersionRuntime, sourceDateEpoch: process.env.SOURCE_DATE_EPOCH };
+          writeFileSync(path.join(process.env.RUNNER_TEMP, 'server-acceptance', 'build.json'), JSON.stringify(evidence, null, 2) + '\n');
+          NODE
+          cat "$RUNNER_TEMP/server-acceptance/build.json" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload canonical archive and checksum
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gajae-app-server-linux-${{ steps.metadata.outputs.source_sha }}
+          path: release/server/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Upload build provenance
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gajae-server-linux-provenance-${{ steps.metadata.outputs.source_sha }}
+          path: ${{ runner.temp }}/server-acceptance/build.json
+          if-no-files-found: error
+          retention-days: 14
+
+  archive-smoke:
+    name: Accept server archive on ${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            glibc: '2.35'
+          - os: ubuntu-24.04
+            glibc: '2.39'
+    env:
+      SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+      ASSET_NAME: ${{ needs.build.outputs.asset_name }}
+      EXPECTED_GLIBC: ${{ matrix.glibc }}
+    steps:
+      - name: Checkout smoke harness at the build source commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.build.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Set up pinned host Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.22.2'
+          architecture: x64
+
+      - name: Check validation host
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(uname -s)" = Linux
+          test "$(uname -m)" = x86_64
+          test "$(getconf GNU_LIBC_VERSION)" = "glibc $EXPECTED_GLIBC"
+          test "$(node --version)" = v22.22.2
+          # Intentionally no npm install in validation: resolve only shipped deps.
+          test ! -e node_modules
+          ARCHIVE_ROOT="$RUNNER_TEMP/gajae-server-archive"
+          EVIDENCE_ROOT="$RUNNER_TEMP/server-acceptance"
+          echo "ARCHIVE_ROOT=$ARCHIVE_ROOT" >> "$GITHUB_ENV"
+          echo "EVIDENCE_ROOT=$EVIDENCE_ROOT" >> "$GITHUB_ENV"
+          mkdir -p "$EVIDENCE_ROOT"
+          printf 'source=%s\nhost=%s\nnode=%s\n' "$SOURCE_SHA" "$(getconf GNU_LIBC_VERSION)" "$(node --version)" > "$EVIDENCE_ROOT/host.txt"
+
+      - name: Download the build archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gajae-app-server-linux-${{ needs.build.outputs.source_sha }}
+          path: ${{ runner.temp }}/server-assets
+
+      - name: Download build provenance
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gajae-server-linux-provenance-${{ needs.build.outputs.source_sha }}
+          path: ${{ runner.temp }}/server-acceptance
+
+      - name: Verify and extract the same archive outside the checkout
+        run: |
+          set -euo pipefail
+          shopt -s nullglob dotglob
+          assets=("$RUNNER_TEMP/server-assets/"*)
+          test "${#assets[@]}" -eq 2
+          test -f "$RUNNER_TEMP/server-assets/$ASSET_NAME"
+          test -f "$RUNNER_TEMP/server-assets/$ASSET_NAME.sha256"
+          (cd "$RUNNER_TEMP/server-assets" && sha256sum --check "$ASSET_NAME.sha256")
+          node --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import { readFileSync } from 'node:fs';
+          import path from 'node:path';
+          const evidence = JSON.parse(readFileSync(path.join(process.env.EVIDENCE_ROOT, 'build.json'), 'utf8'));
+          const checksum = readFileSync(path.join(process.env.RUNNER_TEMP, 'server-assets', `${process.env.ASSET_NAME}.sha256`), 'utf8').split(/\s+/)[0];
+          assert.equal(evidence.sourceSha, process.env.SOURCE_SHA);
+          assert.equal(evidence.asset, process.env.ASSET_NAME);
+          assert.equal(evidence.sha256, checksum);
+          assert.equal(evidence.node, '22.22.2');
+          assert.equal(evidence.glibc, '2.35');
+          NODE
+          mkdir "$ARCHIVE_ROOT"
+          tar -xzf "$RUNNER_TEMP/server-assets/$ASSET_NAME" -C "$ARCHIVE_ROOT"
+          VERSION="$(node -p "require('./package.json').version")"
+          ARCHIVE_VERSION="$(node -p 'require(process.env.ARCHIVE_ROOT + "/package.json").version')"
+          test "$ARCHIVE_VERSION" = "$VERSION"
+
+      - name: Check authenticated startup, native closure, worker, abort and replay
+        run: |
+          set -euo pipefail
+          node scripts/release/smoke-packaged-server.mjs --server-archive-root "$ARCHIVE_ROOT" 2>&1 | tee "$EVIDENCE_ROOT/standard.log"
+
+      - name: Check data survival across graceful shutdown and restart
+        run: |
+          set -euo pipefail
+          node scripts/release/smoke-packaged-server.mjs --server-archive-root "$ARCHIVE_ROOT" --data-survival 2>&1 | tee "$EVIDENCE_ROOT/data-survival.log"
+
+      - name: Record acceptance
+        run: |
+          set -euo pipefail
+          printf 'Accepted %s on %s (glibc %s), source %s\n' "$ASSET_NAME" "$RUNNER_OS" "$EXPECTED_GLIBC" "$SOURCE_SHA" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gajae-server-linux-evidence-${{ matrix.os }}-${{ needs.build.outputs.source_sha }}
+          path: ${{ runner.temp }}/server-acceptance/
+          if-no-files-found: warn
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Gajae Code App are documented in this file. Current and
 future desktop and server artifacts are published only through
 [GitHub Releases](https://github.com/devswha/gajae-code-app/releases).
 
+## 2.0.0-beta.9 (2026-09-06)
+
+- Managed session worktrees and visible, persistent goals with pause, resume
+  and cancellation. Delegated work inherits the parent's account, model,
+  permissions and cancellation through app-owned sessions.
+- GJC conversation search, provider-qualified model choices, stable model
+  picker layout, and correct replay/history reconciliation across reconnects.
+- Preserve streaming tool metadata and errors, and wait for confirmed worker
+  cleanup before reporting a stopped run.
+- Native Linux deb/AppImage packaging and separate Linux server archive
+  acceptance on Ubuntu 22.04 and 24.04.
+- Desktop UI preferences survive relaunch through a preserved loopback origin.
+  macOS acceptance supports separate WebKit and server profiles without copying
+  the user's data or credentials.
+- GJC SDK 0.16.4, signed-release validation, exact server archive identity
+  checks, and source-bound artifact verification.
+
 ## 2.0.0-beta.8 (2026-09-03)
 
 Same-day follow-up to beta.7, driven by first-install testing on a clean

--- a/docs/DESKTOP-QA-PROFILE.md
+++ b/docs/DESKTOP-QA-PROFILE.md
@@ -23,6 +23,13 @@ copy the normal agent credential database into QA. The profile does not grant
 credentials, change app permissions, or disable workflow guards.
 
 Quit and relaunch the same binary with the same argument to check persistence.
+The desktop stores its first verified loopback port in `desktop-port` in the
+profile's app data directory and reuses it. This keeps local UI settings on the
+same origin. Per-launch API credentials still rotate, and PID/health identity
+verification precedes navigation. An occupied saved port causes recovery rather
+than silently choosing a different origin; release the conflicting listener
+and Retry. The normal desktop uses its own app-local data directory for this
+record. A first launch cannot recover preferences from older random ports.
 Use a second empty profile to check that sidebar data and appearance settings
 are independent. Verify the supervised Node process exits after quitting.
 The dedicated WebKit store is managed by macOS and persists independently of

--- a/docs/DESKTOP-QA-PROFILE.md
+++ b/docs/DESKTOP-QA-PROFILE.md
@@ -1,0 +1,43 @@
+# Isolated macOS desktop acceptance
+
+The installed binary accepts an explicit `--qa-profile /absolute/directory`
+on macOS 14 or newer. Ordinary launches keep the normal user profile. QA
+launches use a separate persistent WebKit data-store UUID, application/agent
+database, home, scratch projects, browser caches and instance lock. The server
+environment is rebuilt from an allowlist, so parent provider keys, custom
+agent paths, Node options and shell configuration are not inherited.
+
+Use a fresh empty directory outside the checkout and an accepted app copy:
+
+```sh
+QA_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/gajae-desktop-qa.XXXXXX")"
+QA_ROOT="$(cd "$QA_ROOT" && pwd -P)"
+"/absolute/path/Gajae Code App.app/Contents/MacOS/gajae-app-desktop" \
+  --qa-profile "$QA_ROOT"
+```
+
+Only empty directories or existing profiles with a matching root-bound
+`desktop-qa-profile.json` are accepted. Existing user/project directories,
+copied profile manifests and symlinked managed directories are refused. Do not
+copy the normal agent credential database into QA. The profile does not grant
+credentials, change app permissions, or disable workflow guards.
+
+Quit and relaunch the same binary with the same argument to check persistence.
+Use a second empty profile to check that sidebar data and appearance settings
+are independent. Verify the supervised Node process exits after quitting.
+The dedicated WebKit store is managed by macOS and persists independently of
+the filesystem profile; keep its UUID with the QA evidence. Deleting the QA
+directory alone does not erase that WebKit store. QA profiles are not portable.
+No production browser profile is inspected or copied by this mechanism.
+
+macOS 11–13 still support normal app launches, but QA mode refuses startup
+there rather than silently falling back to WebKit's default store. Other
+platforms reject this option. A disposable OS account remains useful for
+first-install permissions/LaunchServices testing and is required on older
+macOS versions. Profile-based GUI checks do not claim clean-machine coverage.
+
+Record the source commit/tree, artifact hashes, profile UUIDs and separate
+results for launch, sign-in link, settings/project persistence, fresh-profile
+isolation, quit and child-process cleanup. Do not put authentication callback
+URLs, cookies, keys or passwords in the record. OMG skill execution is outside
+the current acceptance scope at the user's request.

--- a/docs/SERVER-LINUX-ACCEPTANCE.md
+++ b/docs/SERVER-LINUX-ACCEPTANCE.md
@@ -1,0 +1,113 @@
+# Linux server archive acceptance
+
+`.github/workflows/server-linux.yml` builds and checks the canonical self-hosted
+server archive independently of desktop packaging and release publication.
+The supported deployment contract remains [SELF-HOST.md](SELF-HOST.md).
+
+## Source and artifacts
+
+The workflow runs for relevant pull-request and main changes, or by manual
+dispatch. A dispatch can specify `source_sha`, a full lowercase 40-character
+commit ID; an empty input selects the dispatched commit. Pull requests select
+their head commit. Every checkout is pinned to that SHA, including both smoke
+jobs. A PR run therefore proves its head, not the eventual merge commit.
+
+Builds run on Ubuntu 22.04, assert glibc **2.35** and Node **22.22.2**, fetch
+Bun **1.4.0**, and run `npm run server:bundle`. That existing builder rebuilds
+native Node dependencies and audits glibc symbol requirements. The archive's
+timestamps use the source commit time through `SOURCE_DATE_EPOCH`.
+
+The build artifact contains exactly:
+
+- `gajae-app-server-<package.version>-linux-x64-node22.tar.gz`
+- The same filename with `.sha256` appended.
+
+A separate `build.json` records the full source SHA, filename, SHA-256, Node
+and glibc versions, and source timestamp. Both validation jobs download the
+same archive and provenance from the build job, verify the checksum and source
+binding, and check the extracted package version against the source checkout.
+They do not rebuild or install npm dependencies.
+
+The workflow has only `contents: read`, disables persisted checkout credentials,
+and uses the action revisions pinned in the repository. It does not access
+release environments, provider/signing secrets, publish releases, dispatch other
+workflows, or announce results. Artifact upload is build output, not publication.
+Source `npm run verify` remains the separate CI gate.
+
+## Runtime acceptance
+
+The Ubuntu 22.04/glibc 2.35 and Ubuntu 24.04/glibc 2.39 jobs each extract under
+`RUNNER_TEMP`, then invoke the existing packaged-server harness with
+`--server-archive-root`. The harness makes an independent disposable copy,
+rejects ancestor dependency fallback, external payload symlinks and `.env`, and
+launches host Node with `scripts/gajae-app-runtime.mjs start` from the archive.
+
+Standard smoke verifies:
+
+- Health identity/version and real frontend HTML plus its compiled JS asset.
+- Normal server owner authentication with a generated deployment API key;
+  missing/invalid keys and foreign origins are rejected on HTTP and WebSocket.
+- Packaged SQLite, node-pty, lightningcss, GJC native manifest hashes and version
+  sentinel, pinned Bun, Rust core, and ripgrep execution.
+- A real packaged Bun worker `worker.initialize`/`worker.shutdown` handshake,
+  including success acknowledgements and graceful process exit, without a
+  provider login or model completion.
+- Authenticated GJC job admission, confirmed abort, and ordered durable terminal
+  replay, plus migration of a preserved v6 jobs database to v7.
+- Socket-local job subscriptions, replay and malformed-request recovery, and
+  real terminal spawn/input/resize/reconnect/exit behavior.
+
+Data survival is a **separate invocation**. It boots twice against the same
+disposable data directory, preserving an auth database project row, a GJC job,
+and gap-free interruption events across graceful shutdown. It checks resume
+admission, abort cleanup, and idempotent SQLite schemas. Each boot receives a
+new test API key, so the replaced fixture key must fail. This does not assert
+that production deployment keys automatically rotate on restart.
+
+Archive smoke never accepts `--project-dir`: it creates a private HOME and a
+temporary Git project under the user's home, then removes only its own fixture
+and copied payload. Provider credentials, Node loader overrides, configuration
+roots and the caller's project are not inherited. No paid/provider inference
+or destructive testing on a user project is part of acceptance.
+
+## Local reproduction and release preparation
+
+On a native Linux x64 host with Node 22.22.2 or newer within Node 22, checksum
+verify the canonical archive and extract it outside any source checkout:
+
+```sh
+ASSET=gajae-app-server-<version>-linux-x64-node22.tar.gz
+sha256sum --check "$ASSET.sha256"
+ARCHIVE_ROOT="$(mktemp -d)"
+tar -xzf "$ASSET" -C "$ARCHIVE_ROOT"
+node /path/to/exact-source/scripts/release/smoke-packaged-server.mjs \
+  --server-archive-root "$ARCHIVE_ROOT"
+node /path/to/exact-source/scripts/release/smoke-packaged-server.mjs \
+  --server-archive-root "$ARCHIVE_ROOT" --data-survival
+```
+
+Keep the canonical archive and checksum together. For release preparation,
+select artifacts whose `build.json.sourceSha` equals the **final release source
+commit** and whose complete workflow succeeded on both Ubuntu versions. A
+build-only artifact, an earlier PR head, a locally built Ubuntu 24.04 archive,
+or desktop deb/AppImage acceptance is insufficient. Record source CI results
+separately. After any source change or merge, rebuild and accept the final SHA;
+do not relabel an earlier archive as that commit.
+
+Download the canonical artifact and both Ubuntu evidence artifacts while they
+are retained (14 days). Each evidence artifact includes provenance, host
+versions, and separate standard/data-survival logs; failed checks also upload
+available diagnostics. Publishing or running the independent release workflow
+is a separate parent/release-owner action.
+
+Focused source checks:
+
+```sh
+node --test scripts/release/packaged-server-paths.test.mjs \
+  scripts/release/server-archive-smoke.test.mjs
+```
+
+These regression tests cover CLI/host guards, archive containment and missing
+dependencies, normal authentication, worker failure/timeout handling, and abort
+replay evidence. They do not establish Linux binary compatibility; that requires
+the real archive checks on both Ubuntu runners.

--- a/docs/V2-SESSION-HANDOFF.md
+++ b/docs/V2-SESSION-HANDOFF.md
@@ -1,6 +1,20 @@
 # gajae-app v2 — Session Handoff (resume state)
 
-Last updated: 2026-09-05 (adversarial review and nine-skill live acceptance). Supersedes the 2026-07-18 handoff.
+Last updated: 2026-09-06 (post-#39 app and release acceptance). Supersedes the 2026-07-18 handoff.
+
+## Current task scope
+
+PRs #30, #35, #38 and #39 are merged. The owner has excluded OMG skill testing;
+do not carry cross-model or user-skill execution forward as required remaining
+work. Historical issue #3 is not thereby proven resolved. App-owned tool-result
+delivery, desktop persistence and release artifacts remain in scope.
+
+The beta.9 candidate adds dedicated macOS QA profiles and Linux server archive
+acceptance. See `DESKTOP-QA-PROFILE.md`, `SERVER-LINUX-ACCEPTANCE.md` and
+`scripts/release/LOCAL-RELEASE.md`. Local signing uses the existing identity and
+notary profile without exporting credentials; hosted signing secrets are still
+absent. Verify actual publication in GitHub rather than inferring it from the
+candidate package version. The older session records below are historical.
 
 ## TL;DR
 

--- a/docs/plans/followup-acceptance.md
+++ b/docs/plans/followup-acceptance.md
@@ -1,5 +1,12 @@
 # Remaining-work integration and acceptance
 
+The owner subsequently excluded OMG skill testing on September 6. The skill
+results below are historical evidence, not outstanding acceptance work. Current
+work covers app behavior and release acceptance, including ordinary tool-result
+delivery and desktop persistence. Cross-model OMG qualification is not required
+for that scope, and the historical upstream issue is not marked fixed by this
+scope change.
+
 This follows PRs #30, #35 and #38, all merged after their required checks.
 All implementation/review agents and actual model requests used Astra with
 xhigh reasoning. Offline tests use controlled transports rather than another
@@ -82,9 +89,11 @@ delegation returned the fixture heading through task/subagent.
   `APPLE_APP_PASSWORD`. Local identity/profile readiness does not configure CI.
 - Windows execution and full interactive GNOME/KDE sessions are not claimed.
   Conversation forks and split panes remain separately deferred product scope.
-- Fresh macOS GUI acceptance requires a disposable macOS account: existing
-  environment overrides do not isolate the WebKit data store. Browser UI and
-  package/signature checks are separate evidence.
+- HOME/database overrides alone did not isolate WebKit. The subsequent
+  `--qa-profile` implementation adds a dedicated persistent WebKit store and
+  server paths for macOS 14+. See `../DESKTOP-QA-PROFILE.md`. Clean-machine
+  permissions and LaunchServices coverage still require a separate OS account;
+  profile GUI, browser UI and package/signature checks remain separate evidence.
 - Issue #3 remains open for the original Cursor/Anthropic live qualification
   and native skill/CLI efficiency. The requested Astra-only lane now completes
   the bundled workflows; it does not establish those other-provider results or

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gajae-app",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gajae-app",
-      "version": "2.0.0-beta.8",
+      "version": "2.0.0-beta.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "gajae-app",
   "private": true,
-  "version": "2.0.0-beta.8",
-  "desktopVersion": "0.2.2",
+  "version": "2.0.0-beta.9",
+  "desktopVersion": "0.2.3",
   "productName": "Gajae Code App",
   "description": "A self-hosted web and desktop interface for GJC",
   "type": "module",

--- a/scripts/release/MACOS-ACCEPTANCE.md
+++ b/scripts/release/MACOS-ACCEPTANCE.md
@@ -7,8 +7,7 @@ draft, public release, workflow run, or export signing credentials. Run the
 blocks in order in the same **Bash** shell on the existing arm64 Mac. Keep the
 output directory until the acceptance record and artifacts are handed off.
 
-The release review checkout still has SDK 0.15.6 installed and no bundled Bun;
-it is not a final build input. The candidate below requires SDK **0.16.4** in
+The candidate below requires SDK **0.16.4** in
 the selected source, installed dependencies, and packaged copy. A future SDK
 upgrade requires reviewing that expectation before using these commands.
 
@@ -170,12 +169,18 @@ isolated home/project data and removes inherited provider credentials. Leave
 These startup, admission/abort, replay and persistence checks do not establish
 a successful live model response.
 
-The parent must finish GUI acceptance from this exact copied app in a
-disposable macOS account: sign-in link, launch/quit/relaunch, persistence, and
-confirmation that the child server exits with the app. Record that result
+The parent must finish GUI acceptance from this exact copied app using a
+disposable macOS account or, on macOS 14+, the explicit `--qa-profile` mode in
+`docs/DESKTOP-QA-PROFILE.md`: sign-in link, launch/quit/relaunch, persistence,
+profile separation and confirmation that the child server exits with the app.
+The QA mode uses the public Webview builder setter because the pinned runtime
+does not carry the data-store UUID through its configuration conversion. An
+environment-only HOME override is insufficient. Record the GUI result
 separately from build, notarization, and packaged-server results. Any authorized
 live provider test must use only `openai/gpt-6-astra` with effort `xhigh` and
-retain the app permission guard; do not enable raw SDK child delegation.
+retain the app permission guard; do not enable raw SDK child delegation. OMG
+skill testing is excluded by the current user instruction. Profile-based GUI
+acceptance does not establish fresh OS permissions or clean-machine behavior.
 
 Record the full commit, package/desktop/SDK and bundled runtime versions, DMG
 hash, both notarization submission IDs, and each acceptance result. Linux

--- a/scripts/release/build-server-bundle.js
+++ b/scripts/release/build-server-bundle.js
@@ -6,6 +6,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { SERVER_PACKAGE_NAME } from '../../shared/productIdentity.js';
 import { isolatedQaEnvironment } from '../start-isolated-dev.mjs';
 
 import { describeDistributionExclusions, removeExcludedDistributionPackages } from './distribution-exclusions.mjs';
@@ -282,7 +283,7 @@ async function writeInstallPackageJson(stageDir, packageJson) {
 
 async function writeRuntimePackageJson(stageDir, packageJson) {
   const runtimePackageJson = {
-    name: 'gajae-app-server',
+    name: SERVER_PACKAGE_NAME,
     version: packageJson.version,
     private: true,
     description: 'Gajae Code App server runtime',

--- a/scripts/release/local-release.mjs
+++ b/scripts/release/local-release.mjs
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
-import { ARTIFACT_PREFIX, PACKAGE_NAME } from '../../shared/productIdentity.js';
+import { ARTIFACT_PREFIX, PACKAGE_NAME, SERVER_PACKAGE_NAME } from '../../shared/productIdentity.js';
 
 import { releaseCommand } from './local-release-command.mjs';
 import { verifyMacosRelease } from './local-release-macos.mjs';
@@ -141,7 +141,7 @@ export async function processLocalRelease(options, {
     const members = (await run('tar', ['-tzf', archive])).stdout.split('\n').filter(name => name === 'package.json' || name === './package.json');
     demand(members.length === 1, 'Server archive must have exactly one root package.json.');
     const server = JSON.parse((await run('tar', ['-xOzf', archive, '--', members[0]])).stdout);
-    demand(server.name === PACKAGE_NAME && server.version === options.version, 'Server archive package/version does not match the release tag.');
+    demand(server.name === SERVER_PACKAGE_NAME && server.version === options.version, 'Server archive package/version does not match the release tag.');
     await verifyMac({ dmg: join(root, options.dmgName), root, teamId: options.teamId,
       version: options.version, desktopVersion: source.desktopVersion }, { run });
 

--- a/scripts/release/local-release.test.mjs
+++ b/scripts/release/local-release.test.mjs
@@ -18,10 +18,10 @@ const serverName = `gajae-app-server-${version}-linux-x64-node22.tar.gz`;
 const sha = bytes => createHash('sha256').update(bytes).digest('hex');
 const packageFor = value => ({ name: 'gajae-app', version: value, desktopVersion: '0.2.2' });
 
-async function fixture(t, { serverVersion = version } = {}) {
+async function fixture(t, { serverVersion = version, serverPackage = 'gajae-app-server' } = {}) {
   const directory = await mkdtemp(join(tmpdir(), 'gajae-release-test-'));
   t.after(() => rm(directory, { recursive: true, force: true }));
-  await writeFile(join(directory, 'package.json'), JSON.stringify(packageFor(serverVersion)));
+  await writeFile(join(directory, 'package.json'), JSON.stringify({ name: serverPackage, version: serverVersion }));
   const archive = join(directory, serverName);
   await releaseCommand('tar', ['-czf', archive, '-C', directory, 'package.json']);
   const files = new Map([[dmgName, Buffer.from('signed image fixture')], [serverName, await readFile(archive)]]);
@@ -190,6 +190,9 @@ test('source commit and server archive version mismatches prevent publication ev
   const wrongServer = await fixture(t, { serverVersion: '1.0.0' });
   await assert.rejects(wrongServer.execute({ publish: true }), /Server archive package/);
   assert.deepEqual(wrongServer.mutations, []);
+  const sourcePackageInArchive = await fixture(t, { serverPackage: 'gajae-app' });
+  await assert.rejects(sourcePackageInArchive.execute({ publish: true }), /Server archive package/);
+  assert.deepEqual(sourcePackageInArchive.mutations, []);
 });
 
 test('macOS signature/acceptance failure never calls the publication API', async t => {

--- a/scripts/release/server-archive-smoke.test.mjs
+++ b/scripts/release/server-archive-smoke.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import { ancestorNodeModules } from './out-of-tree.mjs';
+import { smokeEnvironment, smokeLocation } from './packaged-server-paths.mjs';
+import { assertServerArchiveHost, bootstrap, launch, parseSmokeOptions, serverArchiveTarget, stop, verifyAbortedReplay, workerInitializationSmoke } from './smoke-packaged-server.mjs';
+
+async function temporary(t) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'gajae-archive-test-'));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  return fs.realpath(directory);
+}
+
+async function fixture(t) {
+  const directory = await temporary(t);
+  const root = path.join(directory, 'archive with spaces');
+  const files = ['scripts/gajae-app-runtime.mjs', 'dist/index.html', 'dist-server/server/index.js', 'dist-server/server/cli.js', 'dist-server/server/gjc-bun-worker.js', 'dist-server/server/gjc-runtime-manifest.json', 'dist-native/bun', 'dist-native/gajae-core'];
+  for (const relative of files) {
+    const file = path.join(root, relative);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, '', { mode: 0o755 });
+  }
+  await fs.writeFile(path.join(root, 'package.json'), JSON.stringify({ name: 'gajae-app-server', version: '2.0.0-test', type: 'module' }));
+  return { directory, root };
+}
+
+test('archive CLI isolates projects and rejects ambiguous layouts or combined smoke modes', () => {
+  const options = parseSmokeOptions(['--server-archive-root', 'archive', '--data-survival']);
+  assert.equal(options.app, path.resolve('archive'));
+  assert.equal(options.linux, true, 'use the existing portable out-of-tree copy');
+  assert.equal(options.serverArchive, true);
+  assert.equal(options.dataSurvival, true);
+  assert.equal(options.projectDir, null);
+  assert.equal(parseSmokeOptions(['--server-archive-root', 'archive', '--from-copy']).fromCopy, true);
+  for (const extra of [[], ['--data-survival'], ['root', '--server-archive-root', 'other'], ['root', '--tauri-app', 'app'], ['root', '--linux-root', 'deb'], ['root', '--project-dir', '/user/project'], ['root', '--appimage-env'], ['root', '--unknown'], ['root', '--data-survival', '--data-survival']]) {
+    assert.throws(() => parseSmokeOptions(['--server-archive-root', ...extra]), /Usage: --server-archive-root/);
+  }
+  assert.equal(parseSmokeOptions(['--linux-root', 'deb']).serverArchive, undefined);
+  assert.equal(parseSmokeOptions(['--tauri-app', 'app']).linux, false);
+});
+
+test('archive host gate enforces the documented platform, Node floor and glibc floor', () => {
+  const baseline = { platform: 'linux', arch: 'x64', node: '22.22.2', glibc: '2.35' };
+  for (const host of [baseline, { ...baseline, node: '22.23.1', glibc: '2.39' }]) assert.doesNotThrow(() => assertServerArchiveHost(host));
+  for (const overrides of [{ platform: 'darwin' }, { arch: 'arm64' }, { node: '24.15.0' }, { node: '22.22.1' }, { node: '22.21.9' }, { glibc: '2.34' }, { glibc: '' }]) {
+    assert.throws(() => assertServerArchiveHost({ ...baseline, ...overrides }), /Server archive smoke requires/);
+  }
+});
+
+test('archive target uses host Node and the canonical start command without a desktop sidecar', async t => {
+  const { root } = await fixture(t);
+  const target = await serverArchiveTarget(root);
+  assert.equal(target.command, process.execPath);
+  assert.equal(target.cwd, root);
+  assert.equal(target.serverArchive, true);
+  assert.equal(target.expectedVersion, '2.0.0-test');
+  assert.deepEqual(target.args, [path.join(root, 'scripts/gajae-app-runtime.mjs'), 'start']);
+  assert.equal(target.bun, path.join(root, 'dist-native/bun'));
+  await assert.rejects(fs.access(path.join(root, 'server')), { code: 'ENOENT' }, 'archives ship the compiled manifest, not a source server directory');
+});
+
+test('archive target rejects missing payloads, non-executable runtimes and live configuration', async t => {
+  for (const [name, mutate, expected] of [
+    ['missing CLI', root => fs.rm(path.join(root, 'scripts/gajae-app-runtime.mjs')), /gajae-app-runtime/],
+    ['missing frontend', root => fs.rm(path.join(root, 'dist/index.html')), /index.html/],
+    ['missing worker', root => fs.rm(path.join(root, 'dist-server/server/gjc-bun-worker.js')), /gjc-bun-worker/],
+    ['missing manifest', root => fs.rm(path.join(root, 'dist-server/server/gjc-runtime-manifest.json')), /gjc-runtime-manifest/],
+    ['missing Bun', root => fs.rm(path.join(root, 'dist-native/bun')), /bun/],
+    ['non-executable core', root => fs.chmod(path.join(root, 'dist-native/gajae-core'), 0o644), /EACCES/],
+    ['env credentials', root => fs.writeFile(path.join(root, '.env'), 'API_KEY=fixture'), /containing .env/],
+    ['wrong metadata', root => fs.writeFile(path.join(root, 'package.json'), '{}'), /canonical/],
+  ]) {
+    await t.test(name, async t => {
+      const { root } = await fixture(t);
+      await mutate(root);
+      await assert.rejects(serverArchiveTarget(root), expected);
+    });
+  }
+});
+
+test('archive links and dependency resolution cannot escape into the source checkout', async t => {
+  const { directory, root } = await fixture(t);
+  const shadow = path.join(directory, 'node_modules', 'repository-only-fixture');
+  await fs.mkdir(shadow, { recursive: true });
+  await fs.writeFile(path.join(shadow, 'index.js'), 'module.exports = true;');
+  await assert.rejects(serverArchiveTarget(root), /module resolution would fall back/);
+  await fs.mkdir(path.join(root, 'node_modules', '.bin'), { recursive: true });
+  await fs.mkdir(path.join(root, 'node_modules', 'tool'));
+  await fs.writeFile(path.join(root, 'node_modules/tool/cli.js'), '', { mode: 0o751 });
+  await fs.symlink('../tool/cli.js', path.join(root, 'node_modules/.bin/tool'));
+  const location = await smokeLocation(root, { linux: true });
+  t.after(location.cleanup);
+  const target = await serverArchiveTarget(location.app);
+  assert.equal(await ancestorNodeModules(target.cwd), null);
+  assert.equal(await fs.readlink(path.join(target.cwd, 'node_modules/.bin/tool')), '../tool/cli.js');
+  assert.equal((await fs.stat(path.join(target.cwd, 'node_modules/.bin/tool'))).mode & 0o777, 0o751);
+  const probe = "require.resolve('repository-only-fixture')";
+  assert.equal(spawnSync(process.execPath, ['-e', probe], { cwd: root }).status, 0);
+  const isolated = spawnSync(target.command, ['-e', probe], { cwd: target.cwd, env: smokeEnvironment(target, directory, {}), encoding: 'utf8' });
+  assert.notEqual(isolated.status, 0);
+  assert.match(isolated.stderr, /Cannot find module/);
+  await fs.symlink(shadow, path.join(target.cwd, 'node_modules/escaped'));
+  await assert.rejects(serverArchiveTarget(target.cwd), /escapes extracted root/);
+  await location.cleanup();
+  await fs.access(root);
+});
+
+test('worker smoke requires initialize acknowledgement and graceful shutdown, and reaps failures', { timeout: 15_000 }, async t => {
+  for (const [name, behavior, expected] of [
+    ['valid handshake', 'ok', null],
+    ['initialization rejected', 'reject-init', /rejected initialize/],
+    ['shutdown rejected', 'reject-shutdown', /rejected shutdown/],
+    ['missing shutdown acknowledgement', 'omit-shutdown', /phase=shutdown/],
+    ['nonzero exit after acknowledgement', 'exit-failure', /exit=7/],
+    ['malformed protocol', 'malformed', /Unexpected token/],
+    ['hung worker', 'hang', /timed out/],
+  ]) {
+    await t.test(name, async t => {
+      const { root } = await fixture(t);
+      const pidFile = path.join(root, 'worker.pid');
+      await fs.writeFile(path.join(root, 'dist-server/server/gjc-bun-worker.js'), `
+        import { createInterface } from 'node:readline';
+        import { writeFileSync } from 'node:fs';
+        writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+        const behavior = ${JSON.stringify(behavior)};
+        const lines = createInterface({ input: process.stdin });
+        lines.on('line', line => {
+          const request = JSON.parse(line);
+          if (behavior === 'hang') { setInterval(() => {}, 1000); return; }
+          if (behavior === 'malformed') { console.log('invalid-json'); return; }
+          const shutdown = request.method === 'worker.shutdown';
+          if (shutdown && behavior === 'omit-shutdown') { process.exit(0); return; }
+          const ok = !(shutdown ? behavior === 'reject-shutdown' : behavior === 'reject-init');
+          console.log(JSON.stringify({ protocolVersion: 1, kind: 'response', id: request.id, payload: { ok } }));
+          if (shutdown) process.exitCode = behavior === 'exit-failure' ? 7 : 0;
+        });
+      `);
+      const target = { cwd: root, bun: process.execPath, command: process.execPath };
+      target.env = smokeEnvironment(target, root, {});
+      const check = workerInitializationSmoke(target, { timeoutMs: behavior === 'hang' ? 500 : 3000 });
+      if (expected) await assert.rejects(check, expected);
+      else await check;
+      const pid = Number(await fs.readFile(pidFile, 'utf8'));
+      assert.throws(() => process.kill(pid, 0), { code: 'ESRCH' }, 'worker must be reaped before returning');
+    });
+  }
+});
+
+test('archive launch authenticates normal server mode, serves assets and rotates only the fixture key on restart', { timeout: 15_000 }, async t => {
+  const { root } = await fixture(t);
+  const entry = path.join(root, 'scripts/gajae-app-runtime.mjs');
+  await fs.writeFile(entry, `
+    import { createServer } from 'node:http';
+    import assert from 'node:assert/strict';
+    assert.equal(process.argv[2], 'start');
+    assert.equal(process.env.GJC_DESKTOP, undefined);
+    assert.equal(process.env.OPENAI_API_KEY, undefined);
+    assert.equal(process.env.NODE_OPTIONS, undefined);
+    assert.ok(process.env.DATABASE_PATH.startsWith(process.env.HOME));
+    const server = createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      if (req.url === '/health') return res.end(JSON.stringify({ status: 'ok', product: 'gajae-app', protocolVersion: 1, version: '2.0.0-test' }));
+      if (req.headers['x-api-key'] !== process.env.API_KEY) { res.statusCode = 401; return res.end('{}'); }
+      if (req.url === '/api/auth/user') return res.end(JSON.stringify({ user: { id: 1 }, shell: { desktop: false } }));
+      if (req.url === '/') { res.setHeader('content-type', 'text/html'); return res.end('<script type="module" src="/assets/fixture.js"></script>'); }
+      res.setHeader('content-type', 'application/javascript');
+      res.end('console.log("fixture")');
+    });
+    server.listen(Number(process.env.SERVER_PORT), process.env.HOST);
+    process.on('SIGTERM', () => server.close(() => process.exit(0)));
+  `);
+  const target = await serverArchiveTarget(root);
+  target.env = smokeEnvironment(target, root, { OPENAI_API_KEY: 'must-not-leak', NODE_OPTIONS: '--invalid', GJC_DESKTOP: '1' });
+  const first = await launch(target, root, path.join(root, 'project'));
+  t.after(() => stop(first));
+  const session = await bootstrap(first);
+  assert.equal(session.headers['x-api-key'], first.apiKey);
+  assert.equal(session.headers.cookie, undefined);
+  await stop(first);
+  const second = await launch(target, root, path.join(root, 'project'));
+  t.after(() => stop(second));
+  await bootstrap(second);
+  assert.notEqual(second.apiKey, first.apiKey);
+  const stale = await fetch(`${second.baseUrl}/api/auth/user`, { headers: session.headers });
+  assert.equal(stale.status, 401);
+  second.expectedVersion = 'wrong-version';
+  await assert.rejects(bootstrap(second), /does not match archive metadata/);
+});
+
+test('abort acceptance requires ordered durable terminal evidence for this run', () => {
+  const terminal = { sequence: 2, runId: 'run-1', payload: { kind: 'job_terminal', outcome: 'aborted', jobState: 'aborted' } };
+  const valid = { events: [{ sequence: 1 }, terminal] };
+  assert.doesNotThrow(() => verifyAbortedReplay(valid, 'run-1'));
+  for (const replay of [{}, { events: [] }, { events: [terminal] }, { events: [{ sequence: 1 }, { ...terminal, sequence: 1 }] }, { events: [{ sequence: 1 }, { ...terminal, runId: 'another-run' }] }, { events: [{ sequence: 1 }, { ...terminal, payload: { type: 'aborted' } }] }]) {
+    assert.throws(() => verifyAbortedReplay(replay, 'run-1'), /not gap-free and durable/);
+  }
+});

--- a/scripts/release/server-archive-smoke.test.mjs
+++ b/scripts/release/server-archive-smoke.test.mjs
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 
 import { ancestorNodeModules } from './out-of-tree.mjs';
 import { smokeEnvironment, smokeLocation } from './packaged-server-paths.mjs';
-import { assertServerArchiveHost, bootstrap, launch, parseSmokeOptions, serverArchiveTarget, stop, verifyAbortedReplay, workerInitializationSmoke } from './smoke-packaged-server.mjs';
+import { assertServerArchiveHost, bootstrap, launch, parseSmokeOptions, serverArchiveTarget, stop, verifyAbortedReplay, verifyInterruptedReplay, workerInitializationSmoke } from './smoke-packaged-server.mjs';
 
 async function temporary(t) {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'gajae-archive-test-'));
@@ -191,11 +191,86 @@ test('archive launch authenticates normal server mode, serves assets and rotates
   await assert.rejects(bootstrap(second), /does not match archive metadata/);
 });
 
-test('abort acceptance requires ordered durable terminal evidence for this run', () => {
-  const terminal = { sequence: 2, runId: 'run-1', payload: { kind: 'job_terminal', outcome: 'aborted', jobState: 'aborted' } };
-  const valid = { events: [{ sequence: 1 }, terminal] };
-  assert.doesNotThrow(() => verifyAbortedReplay(valid, 'run-1'));
-  for (const replay of [{}, { events: [] }, { events: [terminal] }, { events: [{ sequence: 1 }, { ...terminal, sequence: 1 }] }, { events: [{ sequence: 1 }, { ...terminal, runId: 'another-run' }] }, { events: [{ sequence: 1 }, { ...terminal, payload: { type: 'aborted' } }] }]) {
-    assert.throws(() => verifyAbortedReplay(replay, 'run-1'), /not gap-free and durable/);
+// Exact replay from the Ubuntu 22.04 beta.9 archive acceptance failure.
+const nativeAbortReplay = {
+  events: [{
+    eventId: 'run-terminal:run-4bd96697-1602-499b-bb50-ecf1e09b16ec',
+    payload: {
+      appSessionId: 'smoke-66188f1a-77c0-4540-81bd-d388b07679f2',
+      jobState: 'aborted', kind: 'job_terminal', outcome: 'aborted', reason: 'aborted',
+      runId: 'run-4bd96697-1602-499b-bb50-ecf1e09b16ec', schemaVersion: 1,
+    },
+    sequence: 1,
+  }],
+  nextCursor: null,
+};
+
+test('abort acceptance reads the run identity from the actual native replay payload', () => {
+  const terminal = nativeAbortReplay.events[0];
+  const runId = terminal.payload.runId;
+  assert.equal(Object.hasOwn(terminal, 'runId'), false);
+  assert.doesNotThrow(() => verifyAbortedReplay(nativeAbortReplay, runId));
+  const prior = { eventId: 'worker-event', sequence: 1, payload: { type: 'output' } };
+  assert.doesNotThrow(() => verifyAbortedReplay({ events: [prior, { ...terminal, sequence: 2 }], nextCursor: null }, runId));
+  for (const mutate of [
+    replay => { replay.events[0].payload.runId = 'another-run'; },
+    replay => { replay.events[0].eventId = 'run-terminal:another-run'; },
+    replay => { replay.events[0].runId = runId; delete replay.events[0].payload.runId; },
+    replay => { replay.events[0].payload.schemaVersion = 2; },
+    replay => { replay.events[0].payload.kind = 'other'; },
+    replay => { replay.events[0].payload.outcome = 'failed'; },
+    replay => { replay.events[0].payload.jobState = 'failed'; },
+    replay => { replay.events.push({ ...terminal, sequence: 2, eventId: 'duplicate-terminal' }); },
+  ]) {
+    const replay = structuredClone(nativeAbortReplay);
+    mutate(replay);
+    assert.throws(() => verifyAbortedReplay(replay, runId), /not gap-free and durable/);
+  }
+});
+
+// jobs.rs::reconcile emits this event; native shutdown does not emit the
+// orchestrator's job_terminal payload or an outer runId field.
+const nativeInterruptedReplay = {
+  events: [{ eventId: 'shutdown-interrupted:run-before-restart', payload: { type: 'interrupted', reason: 'shutdown' }, sequence: 1 }],
+  nextCursor: null,
+};
+
+test('data survival requires the native shutdown event for the interrupted run', () => {
+  const runId = 'run-before-restart';
+  assert.doesNotThrow(() => verifyInterruptedReplay(nativeInterruptedReplay, runId));
+  for (const mutate of [
+    replay => { replay.events[0].eventId = 'shutdown-interrupted:another-run'; },
+    replay => { replay.events[0].payload.type = 'completed'; },
+    replay => { replay.events[0].payload.reason = 'other'; },
+    replay => { replay.events[0].payload = { schemaVersion: 1, kind: 'job_terminal', runId, outcome: 'interrupted', jobState: 'interrupted' }; },
+    replay => { replay.events.push({ ...replay.events[0], sequence: 2, eventId: 'duplicate-interruption' }); },
+  ]) {
+    const replay = structuredClone(nativeInterruptedReplay);
+    mutate(replay);
+    assert.throws(() => verifyInterruptedReplay(replay, runId), /not gap-free, unique, and shutdown-preserved/);
+  }
+});
+
+test('abort and shutdown replay checks reject gaps, duplicates, partial pages and missing run identity', () => {
+  for (const [verify, fixture, runId] of [
+    [verifyAbortedReplay, nativeAbortReplay, nativeAbortReplay.events[0].payload.runId],
+    [verifyInterruptedReplay, nativeInterruptedReplay, 'run-before-restart'],
+  ]) {
+    for (const value of [undefined, '', 1]) assert.throws(() => verify(fixture, value));
+    for (const replay of [null, {}, { events: [], nextCursor: null }]) assert.throws(() => verify(replay, runId));
+    for (const mutate of [
+      replay => { replay.events[0].sequence = 2; },
+      replay => { replay.events[0].sequence = 0; },
+      replay => { replay.events.push({ ...replay.events[0] }); },
+      replay => { replay.events.unshift({ eventId: 'earlier', sequence: 2, payload: {} }); replay.events[1].sequence = 1; },
+      replay => { replay.events.push({ eventId: replay.events[0].eventId, sequence: 2, payload: {} }); },
+      replay => { replay.nextCursor = 1; },
+      replay => { delete replay.nextCursor; },
+      replay => { delete replay.events[0].eventId; },
+    ]) {
+      const replay = structuredClone(fixture);
+      mutate(replay);
+      assert.throws(() => verify(replay, runId));
+    }
   }
 });

--- a/scripts/release/smoke-packaged-server.mjs
+++ b/scripts/release/smoke-packaged-server.mjs
@@ -582,11 +582,36 @@ async function protocolSmoke(target, instance, headers, projectDir) {
   });
 }
 
+function isCompleteUniqueReplay(replay) {
+  return replay?.nextCursor === null && Array.isArray(replay.events) && replay.events.length > 0
+    && replay.events.every((event, index) => event?.sequence === index + 1 && typeof event.eventId === 'string' && event.eventId.length > 0)
+    && new Set(replay.events.map(event => event.eventId)).size === replay.events.length;
+}
+
 export function verifyAbortedReplay(replay, runId) {
-  if (!Array.isArray(replay.events) || !replay.events.length
-      || !replay.events.every((event, index) => event.sequence === index + 1)
-      || !replay.events.some(event => event.runId === runId && event.payload?.kind === 'job_terminal' && event.payload.outcome === 'aborted' && event.payload.jobState === 'aborted')) {
+  const terminalId = `run-terminal:${runId}`;
+  const terminals = Array.isArray(replay?.events) ? replay.events.filter(event => event?.eventId === terminalId || event?.payload?.kind === 'job_terminal') : [];
+  const terminal = terminals[0];
+  // Native JobEvent exposes eventId/sequence/payload; the orchestrator puts
+  // the run identity in JobTerminalPayload, not on the outer replay event.
+  if (typeof runId !== 'string' || !runId || !isCompleteUniqueReplay(replay) || terminals.length !== 1
+      || terminal.eventId !== terminalId || terminal.payload?.schemaVersion !== 1
+      || terminal.payload.runId !== runId || terminal.payload.kind !== 'job_terminal'
+      || terminal.payload.outcome !== 'aborted' || terminal.payload.jobState !== 'aborted') {
     throw new Error(`Aborted GJC event replay was not gap-free and durable: ${JSON.stringify(replay)}`);
+  }
+}
+
+export function verifyInterruptedReplay(replay, runId) {
+  const terminalId = `shutdown-interrupted:${runId}`;
+  const interruptions = Array.isArray(replay?.events) ? replay.events.filter(event => event?.eventId === terminalId || event?.payload?.type === 'interrupted') : [];
+  const interruption = interruptions[0];
+  // Shutdown reconciliation is authored by the native authority. Unlike an
+  // orchestrator terminal payload, its run identity is only in eventId.
+  if (typeof runId !== 'string' || !runId || !isCompleteUniqueReplay(replay) || interruptions.length !== 1
+      || interruption.eventId !== terminalId || interruption.payload?.type !== 'interrupted'
+      || interruption.payload.reason !== 'shutdown') {
+    throw new Error(`Restarted GJC event replay was not gap-free, unique, and shutdown-preserved: ${JSON.stringify(replay)}`);
   }
 }
 
@@ -609,7 +634,7 @@ async function smoke(packagedTarget, suppliedProjectDir) {
     if (!preservedJob || preservedJob.state !== 'succeeded' || preservedJob.lastSequence !== 1 || listedJobs.nextCursor !== null || Object.hasOwn(preservedJob, 'archivedAt')) throw new Error(`v6 GJC job list was not preserved after migration: ${JSON.stringify(listedJobs)}`);
     const create = await request(`${instance.baseUrl}/api/gjc/jobs`, { headers: { ...headers, 'content-type': 'application/json' }, method: 'POST', body: JSON.stringify({ appSessionId: `smoke-${crypto.randomUUID()}`, projectPath: projectDir, message: 'packaged server smoke' }) });
     const job = await json(create, 'GJC job creation');
-    if (create.status !== 202 || typeof job.jobId !== 'string') throw new Error(`GJC job creation returned an invalid response: ${JSON.stringify(job)}`);
+    if (create.status !== 202 || typeof job.jobId !== 'string' || typeof job.runId !== 'string' || !job.runId) throw new Error(`GJC job creation returned an invalid response: ${JSON.stringify(job)}`);
     const abort = await request(`${instance.baseUrl}/api/gjc/jobs/${encodeURIComponent(job.jobId)}/abort`, { headers, method: 'POST' });
     if (abort.status !== 202) throw new Error(`GJC job abort failed (${abort.status}).`);
     if (target.serverArchive) {
@@ -645,7 +670,7 @@ async function dataSurvivalSmoke(packagedTarget, suppliedProjectDir) {
     if (!(await json(project, 'Durable project creation')).success) throw new Error('Durable project creation did not report success.');
     const created = await request(`${first.baseUrl}/api/gjc/jobs`, { headers: { ...firstSession.headers, 'content-type': 'application/json' }, method: 'POST', body: JSON.stringify({ appSessionId: `data-survival-${crypto.randomUUID()}`, projectPath: projectDir, message: 'data survival shutdown fence' }) });
     const job = await json(created, 'Durable GJC job creation');
-    if (created.status !== 202 || typeof job.jobId !== 'string' || typeof job.appSessionId !== 'string') throw new Error(`Durable GJC job creation returned an invalid response: ${JSON.stringify(job)}`);
+    if (created.status !== 202 || typeof job.jobId !== 'string' || typeof job.appSessionId !== 'string' || typeof job.runId !== 'string' || !job.runId) throw new Error(`Durable GJC job creation returned an invalid response: ${JSON.stringify(job)}`);
     await stop(first); first = undefined;
 
     const schemaAfterFirstBoot = { auth: await sqliteSnapshot(target, authDatabase), jobs: await sqliteSnapshot(target, jobsDatabase) };
@@ -660,8 +685,8 @@ async function dataSurvivalSmoke(packagedTarget, suppliedProjectDir) {
     const list = await json(await request(`${second.baseUrl}/api/gjc/jobs`, { headers: secondSession.headers }), 'Restarted GJC job list');
     if (!Array.isArray(list.items) || !list.items.some(item => item?.jobId === job.jobId && item.state === 'interrupted')) throw new Error(`Restarted GJC job was not preserved as interrupted: ${JSON.stringify(list)}`);
     const replayBeforeResume = await json(await request(`${second.baseUrl}/api/gjc/jobs/${encodeURIComponent(job.jobId)}/events?cursor=0`, { headers: secondSession.headers }), 'Restarted GJC event replay');
-    const sequences = replayBeforeResume.events?.map(event => event.sequence);
-    if (!Array.isArray(sequences) || sequences.length === 0 || new Set(sequences).size !== sequences.length || !sequences.every((sequence, index) => sequence === index + 1) || !replayBeforeResume.events.some(event => event?.payload?.type === 'interrupted')) throw new Error(`Restarted GJC event replay was not gap-free, unique, and shutdown-preserved: ${JSON.stringify(replayBeforeResume)}`);
+    verifyInterruptedReplay(replayBeforeResume, job.runId);
+    const sequences = replayBeforeResume.events.map(event => event.sequence);
     const resumed = await request(`${second.baseUrl}/api/gjc/jobs/${encodeURIComponent(job.jobId)}/resume`, { headers: { ...secondSession.headers, 'content-type': 'application/json' }, method: 'POST', body: JSON.stringify({ appSessionId: job.appSessionId, message: 'data survival resume admission' }) });
     const resumedJob = await json(resumed, 'Interrupted GJC job resume');
     if (resumed.status !== 202 || typeof resumedJob.runId !== 'string') throw new Error(`Interrupted GJC job resume returned an invalid response: ${JSON.stringify(resumedJob)}`);

--- a/scripts/release/smoke-packaged-server.mjs
+++ b/scripts/release/smoke-packaged-server.mjs
@@ -1,15 +1,71 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { constants, existsSync } from 'node:fs';
 import crypto from 'node:crypto';
-import { mkdir, realpath, rm, symlink } from 'node:fs/promises';
+import { access, lstat, mkdir, readdir, readFile, realpath, rm, stat, symlink } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import net from 'node:net';
 import path from 'node:path';
 
-import { APPIMAGE_ENV_MARKER, appImageLaunchTarget, createSmokeDataDirectory, packagedTargets, parseSmokeOptions, smokeEnvironment, smokeLocation } from './packaged-server-paths.mjs';
+import { assertOutOfTree } from './out-of-tree.mjs';
+import { APPIMAGE_ENV_MARKER, appImageLaunchTarget, createSmokeDataDirectory, packagedTargets, parseSmokeOptions as parseDesktopSmokeOptions, smokeEnvironment, smokeLocation } from './packaged-server-paths.mjs';
 
 const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+export function parseSmokeOptions(args) {
+  if (!args.includes('--server-archive-root')) return parseDesktopSmokeOptions(args);
+  const usage = 'Usage: --server-archive-root <extracted-dir> [--data-survival] [--from-copy]; archive checks require a disposable fixture project.';
+  if (args.some(arg => ['--linux-root', '--tauri-app', '--project-dir', '--appimage-env'].includes(arg))) throw new Error(usage);
+  try {
+    // Reuse the portable copy/cleanup and argument validation used by Linux
+    // desktop packages. An archive has a different target and authentication.
+    return { ...parseDesktopSmokeOptions(args.map(arg => arg === '--server-archive-root' ? '--linux-root' : arg)), serverArchive: true };
+  } catch (error) { throw new Error(usage, { cause: error }); }
+}
+
+export function assertServerArchiveHost({ platform = process.platform, arch = process.arch, node = process.versions.node, glibc = process.report.getReport().header.glibcVersionRuntime } = {}) {
+  const [major, minor, patch] = node.split('.').map(Number);
+  if (platform !== 'linux' || arch !== 'x64' || major !== 22 || !(minor > 22 || (minor === 22 && patch >= 2))) {
+    throw new Error('Server archive smoke requires Linux x64 and Node 22.22.2+ within Node 22.');
+  }
+  const [libcMajor, libcMinor] = (glibc ?? '').split('.').map(Number);
+  if (libcMajor !== 2 || !(libcMinor >= 35)) throw new Error('Server archive smoke requires glibc 2.35 or newer.');
+}
+
+export async function serverArchiveTarget(root) {
+  root = await realpath(root);
+  await assertOutOfTree(root, 'server archive smoke');
+  const checkContained = async filename => {
+    const relative = path.relative(root, await realpath(filename));
+    if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) throw new Error(`Server archive path escapes extracted root: ${filename}`);
+  };
+  const checkLinks = async directory => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const filename = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) await checkContained(filename);
+      else if (entry.isDirectory()) await checkLinks(filename);
+    }
+  };
+  await checkLinks(root);
+  try {
+    await lstat(path.join(root, '.env'));
+    throw new Error('Server archive smoke refuses a payload containing .env; it could load live credentials.');
+  } catch (error) { if (error.code !== 'ENOENT') throw error; }
+  const required = ['package.json', 'scripts/gajae-app-runtime.mjs', 'dist/index.html', 'dist-server/server/index.js', 'dist-server/server/cli.js', 'dist-server/server/gjc-bun-worker.js', 'dist-server/server/gjc-runtime-manifest.json', 'dist-native/bun', 'dist-native/gajae-core'];
+  for (const relative of required) {
+    const filename = path.join(root, relative);
+    await checkContained(filename);
+    if (!(await stat(filename)).isFile()) throw new Error(`Server archive requires a regular file: ${filename}`);
+  }
+  for (const relative of ['dist-native/bun', 'dist-native/gajae-core']) await access(path.join(root, relative), constants.X_OK);
+  const metadata = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+  if (metadata.name !== 'gajae-app-server' || typeof metadata.version !== 'string' || !metadata.version) throw new Error('Expected canonical gajae-app-server archive metadata.');
+  return {
+    label: 'Linux server archive', serverArchive: true, cwd: root, command: process.execPath,
+    bun: path.join(root, 'dist-native/bun'), args: [path.join(root, 'scripts/gajae-app-runtime.mjs'), 'start'],
+    expectedVersion: metadata.version,
+  };
+}
 
 function request(url, { headers, method = 'GET', body, redirect = 'manual' } = {}) {
   // Force a fresh connection per request: the packaged server may close
@@ -73,7 +129,7 @@ async function prepareSmoke(target, dataDirectory, suppliedProjectDir) {
   return { target: { ...target, env }, projectDir };
 }
 
-function launch(target, dataDirectory, projectDir) {
+export function launch(target, dataDirectory, projectDir) {
   const portPromise = freePort();
   return portPromise.then(port => {
     const baseUrl = `http://127.0.0.1:${port}`;
@@ -86,7 +142,7 @@ function launch(target, dataDirectory, projectDir) {
         ...target.env,
         DATABASE_PATH: path.join(dataDirectory, 'auth.db'),
         GJC_WORKER_AGENT_DIR: path.join(dataDirectory, 'agent'),
-        GJC_DESKTOP: '1', GJC_DESKTOP_API_KEY: apiKey, GJC_DESKTOP_BOOTSTRAP_NONCE: nonce,
+        ...(target.serverArchive ? { API_KEY: apiKey } : { GJC_DESKTOP: '1', GJC_DESKTOP_API_KEY: apiKey, GJC_DESKTOP_BOOTSTRAP_NONCE: nonce }),
         HOME: dataDirectory, WORKSPACES_ROOT: projectDir, HOST: '127.0.0.1', NODE_ENV: 'production', SERVER_PORT: String(port),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -95,7 +151,7 @@ function launch(target, dataDirectory, projectDir) {
     child.stdout.on('data', chunk => { output.value += chunk; });
     child.stderr.on('data', chunk => { output.value += chunk; });
     child.once('error', error => { output.error = error; output.value += `\n${error.message}`; });
-    return { child, baseUrl, nonce, output, appImageEnv: target.appImageEnv };
+    return { child, baseUrl, nonce, apiKey, output, appImageEnv: target.appImageEnv, serverArchive: target.serverArchive, expectedVersion: target.expectedVersion };
   });
 }
 
@@ -114,7 +170,7 @@ async function nativeClosureSmoke(target) {
     if (database.prepare('SELECT 1 AS value').get().value !== 1) throw new Error('better-sqlite3 native smoke failed');
     database.close();
     lightningcss.transform({ filename: 'smoke.css', code: Buffer.from('a { color: red; }') });
-    const manifest = JSON.parse(readFileSync(path.join(process.cwd(), 'server/gjc-runtime-manifest.json'), 'utf8'));
+    const manifest = JSON.parse(readFileSync(path.join(process.cwd(), ${JSON.stringify(target.serverArchive ? 'dist-server/server/gjc-runtime-manifest.json' : 'server/gjc-runtime-manifest.json')}), 'utf8'));
     const platform = process.platform + '-' + process.arch;
     const closure = manifest.platforms[platform]?.files ?? [];
     if (!closure.length) throw new Error('Gajae native manifest is missing for ' + platform);
@@ -132,6 +188,14 @@ async function nativeClosureSmoke(target) {
     if (typeof nativeBindings[sentinel] !== 'function') throw new Error('Gajae native version sentinel is missing');
     const bun = spawnSync(path.join(process.cwd(), 'dist-native', 'bun'), ['--version'], { encoding: 'utf8', timeout: 10000 });
     if (bun.error || bun.status !== 0 || bun.stdout.trim() !== manifest.bun) throw new Error('Bundled Bun version mismatch: ' + (bun.error?.message ?? bun.stderr ?? bun.stdout));
+    if (${Boolean(target.serverArchive)}) {
+      if (manifest.bun !== '1.4.0') throw new Error('Server archive must pin Bun 1.4.0');
+      const core = spawnSync(path.join(process.cwd(), 'dist-native', 'gajae-core'), ['--version'], { encoding: 'utf8', timeout: 10000 });
+      if (core.error || core.status !== 0 || !core.stdout.startsWith('gajae-core ')) throw new Error('Bundled Rust core failed to execute');
+      const { rgPath } = require('@vscode/ripgrep');
+      const rg = spawnSync(rgPath, ['--version'], { encoding: 'utf8', timeout: 10000 });
+      if (rg.error || rg.status !== 0 || !rg.stdout.startsWith('ripgrep ')) throw new Error('Bundled ripgrep failed to execute');
+    }
     await new Promise((resolve, reject) => {
       const terminal = pty.spawn(process.execPath, ['-e', 'process.exit(0)'], { name: 'xterm-256color', cols: 80, rows: 24, cwd: process.cwd(), env: process.env });
       const timer = setTimeout(() => { terminal.kill(); reject(new Error('node-pty native smoke timed out')); }, 5000);
@@ -155,10 +219,64 @@ async function nativeClosureSmoke(target) {
       ? resolve()
       : reject(new Error(`Packaged native closure smoke failed (${code}): ${stderr || stdout}`)));
   });
+  if (target.serverArchive) await workerInitializationSmoke(target);
 }
 
-async function bootstrap(instance) {
+export async function workerInitializationSmoke(target, { timeoutMs = 45_000 } = {}) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(target.bun, [path.join(target.cwd, 'dist-server/server/gjc-bun-worker.js')], {
+      cwd: target.cwd, env: target.env, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let pending = ''; let diagnostic = ''; let failure; let phase = 'initialize';
+    const fail = error => { failure ??= error; child.kill('SIGKILL'); };
+    const timer = setTimeout(() => fail(new Error('Bun worker initialization/shutdown timed out.')), timeoutMs);
+    const send = method => child.stdin.write(`${JSON.stringify({ protocolVersion: 1, kind: 'request', id: `archive-${method}`, method: `worker.${method}`, payload: {} })}\n`);
+    child.stdout.setEncoding('utf8'); child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => { diagnostic += chunk; });
+    child.once('error', fail);
+    child.stdin.on('error', fail);
+    child.stdout.on('data', chunk => {
+      pending += chunk;
+      const lines = pending.split('\n'); pending = lines.pop();
+      try {
+        for (const line of lines.filter(Boolean)) {
+          const frame = JSON.parse(line);
+          if (frame.protocolVersion !== 1 || frame.kind !== 'response' || frame.id !== `archive-${phase}` || frame.payload?.ok !== true) throw new Error(`Bun worker rejected ${phase}: ${line}`);
+          if (phase === 'initialize') { phase = 'shutdown'; send('shutdown'); child.stdin.end(); }
+          else if (phase === 'shutdown') phase = 'closed';
+          else throw new Error('Unexpected extra Bun worker response.');
+        }
+      } catch (error) { fail(error); }
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timer);
+      if (failure || code !== 0 || signal || phase !== 'closed' || pending.trim()) reject(new Error(`Packaged Bun worker handshake failed: ${failure?.message ?? `phase=${phase}, exit=${code}, signal=${signal}`}\n${diagnostic}`));
+      else resolve();
+    });
+    send('initialize');
+  });
+  console.log('Packaged Bun worker initialize/shutdown handshake passed.');
+}
+
+export async function bootstrap(instance) {
   const health = await waitForHealth(instance.baseUrl, instance.output, instance.child);
+  if (instance.serverArchive) {
+    if (health.version !== instance.expectedVersion) throw new Error('Running server version does not match archive metadata.');
+    const headers = { 'x-api-key': instance.apiKey, origin: instance.baseUrl };
+    for (const invalid of [{}, { 'x-api-key': 'invalid-smoke-key' }]) {
+      const denied = await request(`${instance.baseUrl}/api/auth/user`, { headers: invalid });
+      if (denied.status !== 401) throw new Error('Server archive accepted a missing or invalid API key.');
+    }
+    const owner = await json(await request(`${instance.baseUrl}/api/auth/user`, { headers }), 'Server archive owner authentication');
+    if (!owner.user?.id || owner.shell?.desktop !== false) throw new Error('Server archive did not boot with normal server authentication.');
+    const page = await request(`${instance.baseUrl}/`, { headers });
+    const html = await page.text();
+    const asset = html.match(/<script\b[^>]*\bsrc="(\/assets\/[^"?#]+\.js)"/);
+    if (!page.ok || !page.headers.get('content-type')?.includes('text/html') || !asset) throw new Error('Server archive did not serve the built frontend.');
+    const script = await request(`${instance.baseUrl}${asset[1]}`, { headers });
+    if (!script.ok || !script.headers.get('content-type')?.includes('javascript') || !(await script.text()).trim()) throw new Error('Server archive frontend asset is missing.');
+    return { health, headers };
+  }
   if (instance.appImageEnv) {
     if (!instance.output.value.split('\n').includes(APPIMAGE_ENV_MARKER)) throw new Error('AppImage smoke did not execute the instrumented GUI launcher through AppRun.');
     console.log(APPIMAGE_ENV_MARKER);
@@ -256,8 +374,8 @@ async function v7MigrationSnapshot(target, database) {
   return JSON.parse(output.trim());
 }
 
-// Run with the shipped Node and ws module, so checkout dependencies cannot mask
-// a broken package. Every socket uses the disposable desktop boot credential.
+// Resolve ws from the payload, so checkout dependencies cannot mask a broken
+// package. Sockets use only the disposable boot credential for this target.
 async function packagedProtocolChecks() {
   const { default: assert } = await import('node:assert/strict');
   const { once } = await import('node:events');
@@ -265,9 +383,10 @@ async function packagedProtocolChecks() {
   const { test } = await import('node:test');
   const { WebSocket } = createRequire(`${process.cwd()}/package.json`)('ws');
   const base = process.env.GAJAE_SMOKE_URL;
-  const cookie = process.env.GAJAE_SMOKE_COOKIE;
+  const serverArchive = process.env.GAJAE_SMOKE_SERVER_ARCHIVE === '1';
   const project = process.env.GAJAE_SMOKE_PROJECT;
-  const headers = { cookie, origin: base };
+  const headers = JSON.parse(process.env.GAJAE_SMOKE_HEADERS);
+  const cookie = headers.cookie;
   const sockets = new Set();
   const pause = ms => new Promise(resolve => setTimeout(resolve, ms));
   const get = (pathname, requestHeaders = headers) => fetch(`${base}${pathname}`, { headers: { ...requestHeaders, connection: 'close' }, signal: AbortSignal.timeout(5_000) });
@@ -307,16 +426,22 @@ async function packagedProtocolChecks() {
       },
     };
   }
-  await test('packaged desktop HTTP, WebSocket and terminal integration', { timeout: 45_000 }, async t => {
+  await test('packaged HTTP, WebSocket and terminal integration', { timeout: 45_000 }, async t => {
     t.after(() => { for (const socket of sockets) socket.terminate(); });
-    await t.test('HTTP cookie and exact-origin rejection preserve authenticated access', async () => {
-      for (const invalid of [{}, { cookie: 'gajae_desktop_api_key=invalid' }, { cookie, origin: 'http://localhost:1' }]) {
-        assert.equal((await get('/api/gjc/jobs', invalid)).status, 401);
+    await t.test('HTTP rejects invalid credentials and preserves authenticated access', async () => {
+      const invalidHeaders = serverArchive
+        ? [{}, { 'x-api-key': 'invalid-smoke-key' }]
+        : [{}, { cookie: 'gajae_desktop_api_key=invalid' }, { cookie, origin: 'http://localhost:1' }];
+      for (const invalid of invalidHeaders) assert.equal((await get('/api/gjc/jobs', invalid)).status, 401);
+      if (serverArchive) {
+        assert.equal((await get('/api/gjc/jobs', { ...headers, origin: 'https://archive-smoke.invalid' })).status, 403);
+        assert.equal((await get('/api/gjc/jobs', { 'x-api-key': headers['x-api-key'] })).status, 200);
+      } else {
+        assert.equal((await get('/api/gjc/jobs', { cookie })).status, 200);
       }
-      assert.equal((await get('/api/gjc/jobs', { cookie })).status, 200);
       assert.equal((await get('/api/gjc/jobs')).status, 200);
     });
-    if (process.platform === 'linux') {
+    if (process.platform === 'linux' && !serverArchive) {
       await t.test('Linux desktop exposes Workspace Browser without enabling native computer automation', async () => {
         const response = await get('/api/automation/status');
         assert.equal(response.status, 200);
@@ -342,8 +467,11 @@ async function packagedProtocolChecks() {
       }
     }
     for (const pathname of ['/ws', '/shell']) {
-      await t.test(`${pathname} rejects missing/invalid cookie and absent/foreign origin`, async () => {
-        for (const invalid of [{ origin: base }, { origin: base, cookie: 'gajae_desktop_api_key=invalid' }, { cookie }, { cookie, origin: 'http://localhost:1' }]) {
+      await t.test(`${pathname} rejects invalid credentials and foreign origin`, async () => {
+        const invalidHeaders = serverArchive
+          ? [{ origin: base }, { origin: base, 'x-api-key': 'invalid-smoke-key' }, { ...headers, origin: 'https://archive-smoke.invalid' }]
+          : [{ origin: base }, { origin: base, cookie: 'gajae_desktop_api_key=invalid' }, { cookie }, { cookie, origin: 'http://localhost:1' }];
+        for (const invalid of invalidHeaders) {
           await assert.rejects(connect(pathname, invalid), /Unexpected server response: 401/);
         }
       });
@@ -435,7 +563,7 @@ async function protocolSmoke(target, instance, headers, projectDir) {
   await new Promise((resolve, reject) => {
     const child = spawn(target.command, ['--input-type=module', '--eval', source], {
       cwd: target.cwd,
-      env: { ...target.env, GAJAE_SMOKE_URL: instance.baseUrl, GAJAE_SMOKE_COOKIE: headers.cookie, GAJAE_SMOKE_PROJECT: projectDir, GAJAE_SMOKE_APPIMAGE_ENV: target.appImageEnv ? '1' : '0' },
+      env: { ...target.env, GAJAE_SMOKE_URL: instance.baseUrl, GAJAE_SMOKE_HEADERS: JSON.stringify(headers), GAJAE_SMOKE_SERVER_ARCHIVE: target.serverArchive ? '1' : '0', GAJAE_SMOKE_PROJECT: projectDir, GAJAE_SMOKE_APPIMAGE_ENV: target.appImageEnv ? '1' : '0' },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let output = '';
@@ -450,6 +578,14 @@ async function protocolSmoke(target, instance, headers, projectDir) {
       else reject(new Error(`Packaged protocol checks failed (${code}).\n${instance.output.value}`));
     });
   });
+}
+
+export function verifyAbortedReplay(replay, runId) {
+  if (!Array.isArray(replay.events) || !replay.events.length
+      || !replay.events.every((event, index) => event.sequence === index + 1)
+      || !replay.events.some(event => event.runId === runId && event.payload?.kind === 'job_terminal' && event.payload.outcome === 'aborted' && event.payload.jobState === 'aborted')) {
+    throw new Error(`Aborted GJC event replay was not gap-free and durable: ${JSON.stringify(replay)}`);
+  }
 }
 
 async function smoke(packagedTarget, suppliedProjectDir) {
@@ -474,6 +610,12 @@ async function smoke(packagedTarget, suppliedProjectDir) {
     if (create.status !== 202 || typeof job.jobId !== 'string') throw new Error(`GJC job creation returned an invalid response: ${JSON.stringify(job)}`);
     const abort = await request(`${instance.baseUrl}/api/gjc/jobs/${encodeURIComponent(job.jobId)}/abort`, { headers, method: 'POST' });
     if (abort.status !== 202) throw new Error(`GJC job abort failed (${abort.status}).`);
+    if (target.serverArchive) {
+      const result = await json(abort, 'GJC job abort');
+      if (result.aborted !== true) throw new Error('Archive GJC job abort was not confirmed.');
+      const replay = await json(await request(`${instance.baseUrl}/api/gjc/jobs/${encodeURIComponent(job.jobId)}/events?cursor=0`, { headers }), 'Aborted GJC event replay');
+      verifyAbortedReplay(replay, job.runId);
+    }
     await stop(instance);
     const migration = await v7MigrationSnapshot(target, jobsDatabase);
     if (migration.migrationVersion !== 7 || migration.archivedAt !== null) throw new Error(`v6 jobs.sqlite3 did not migrate to v7 with archived_at NULL: ${JSON.stringify(migration)}`);
@@ -507,9 +649,12 @@ async function dataSurvivalSmoke(packagedTarget, suppliedProjectDir) {
     const schemaAfterFirstBoot = { auth: await sqliteSnapshot(target, authDatabase), jobs: await sqliteSnapshot(target, jobsDatabase) };
     second = await launch(target, dataDirectory, projectDir);
     const secondSession = await bootstrap(second);
-    const staleCookie = await request(`${second.baseUrl}/api/gjc/jobs`, { headers: { ...firstSession.headers, origin: second.baseUrl } });
-    const staleNonce = await request(`${second.baseUrl}/desktop/bootstrap?nonce=${encodeURIComponent(firstNonce)}`);
-    if (staleCookie.status !== 401 || staleNonce.status !== 401 || staleNonce.headers.has('set-cookie')) throw new Error('Desktop credentials from the previous boot were accepted.');
+    const staleCredential = await request(`${second.baseUrl}/api/gjc/jobs`, { headers: { ...firstSession.headers, origin: second.baseUrl } });
+    if (staleCredential.status !== 401) throw new Error('The replaced smoke credential from the previous boot was accepted.');
+    if (!target.serverArchive) {
+      const staleNonce = await request(`${second.baseUrl}/desktop/bootstrap?nonce=${encodeURIComponent(firstNonce)}`);
+      if (staleNonce.status !== 401 || staleNonce.headers.has('set-cookie')) throw new Error('Desktop nonce from the previous boot was accepted.');
+    }
     const list = await json(await request(`${second.baseUrl}/api/gjc/jobs`, { headers: secondSession.headers }), 'Restarted GJC job list');
     if (!Array.isArray(list.items) || !list.items.some(item => item?.jobId === job.jobId && item.state === 'interrupted')) throw new Error(`Restarted GJC job was not preserved as interrupted: ${JSON.stringify(list)}`);
     const replayBeforeResume = await json(await request(`${second.baseUrl}/api/gjc/jobs/${encodeURIComponent(job.jobId)}/events?cursor=0`, { headers: secondSession.headers }), 'Restarted GJC event replay');
@@ -541,9 +686,10 @@ async function dataSurvivalSmoke(packagedTarget, suppliedProjectDir) {
 
 export async function runPackagedSmoke(args = process.argv.slice(2)) {
   const options = parseSmokeOptions(args);
+  if (options.serverArchive) assertServerArchiveHost();
   const location = await smokeLocation(options.app, options);
   try {
-    let target = await packagedTargets(location.app, options);
+    let target = options.serverArchive ? await serverArchiveTarget(location.app) : await packagedTargets(location.app, options);
     if (options.appImageEnv) target = await appImageLaunchTarget(location, target);
     await (options.dataSurvival ? dataSurvivalSmoke(target, options.projectDir) : smoke(target, options.projectDir));
   } finally {

--- a/scripts/release/smoke-packaged-server.mjs
+++ b/scripts/release/smoke-packaged-server.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 import net from 'node:net';
 import path from 'node:path';
 
+import { SERVER_PACKAGE_NAME } from '../../shared/productIdentity.js';
+
 import { assertOutOfTree } from './out-of-tree.mjs';
 import { APPIMAGE_ENV_MARKER, appImageLaunchTarget, createSmokeDataDirectory, packagedTargets, parseSmokeOptions as parseDesktopSmokeOptions, smokeEnvironment, smokeLocation } from './packaged-server-paths.mjs';
 
@@ -59,7 +61,7 @@ export async function serverArchiveTarget(root) {
   }
   for (const relative of ['dist-native/bun', 'dist-native/gajae-core']) await access(path.join(root, relative), constants.X_OK);
   const metadata = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
-  if (metadata.name !== 'gajae-app-server' || typeof metadata.version !== 'string' || !metadata.version) throw new Error('Expected canonical gajae-app-server archive metadata.');
+  if (metadata.name !== SERVER_PACKAGE_NAME || typeof metadata.version !== 'string' || !metadata.version) throw new Error('Expected canonical gajae-app-server archive metadata.');
   return {
     label: 'Linux server archive', serverArchive: true, cwd: root, command: process.execPath,
     bun: path.join(root, 'dist-native/bun'), args: [path.join(root, 'scripts/gajae-app-runtime.mjs'), 'start'],

--- a/server/gjc-bun-sdk-events.contract.test.ts
+++ b/server/gjc-bun-sdk-events.contract.test.ts
@@ -57,6 +57,16 @@ test('the SDK declarations that back the fan-in are present and readable', () =>
   assert.match(coreEvents, /type\s*:\s*"tool_execution_start"/u);
 });
 
+test('SDK tool updates carry content, structured details and errors on the result envelope', () => {
+  const result = /export interface AgentToolResult[^{]*\{([\s\S]*?)\n\}/u.exec(coreEvents)?.[1];
+  assert.ok(result, 'the SDK still declares its tool result envelope');
+  assert.match(result, /\bcontent\s*:/u);
+  assert.match(result, /\bdetails\?\s*:/u);
+  assert.match(result, /\bisError\?\s*:\s*boolean/u);
+  assert.ok(/type AgentToolUpdateCallback[^\n]*=\s*\(partialResult:\s*AgentToolResult</u.test(coreEvents),
+    'the update callback must deliver the same AgentToolResult envelope');
+});
+
 for (const [eventType, fields] of Object.entries(SDK_EVENT_FIELDS_READ)) {
   test(`SDK event ${eventType} still declares every field the fan-in reads`, () => {
     const body = eventMemberBody(sessionEvents, eventType) ?? eventMemberBody(coreEvents, eventType);

--- a/server/gjc-bun-sdk-events.test.ts
+++ b/server/gjc-bun-sdk-events.test.ts
@@ -115,6 +115,43 @@ test('an empty tool_execution_update emits nothing', () => {
   assert.equal(all(messages, 'tool_result').length, 0);
 });
 
+test('tool_execution_update preserves structured output even without display text', () => {
+  // The SDK bash tool emits the live terminal ID before any stdout exists.
+  const details = { terminalId: 'terminal-1' };
+  const { messages } = forward([
+    { type: 'tool_execution_start', toolCallId: 'terminal-call', toolName: 'bash', args: { command: 'pwd' } },
+    { type: 'tool_execution_update', toolCallId: 'terminal-call', partialResult: { content: [], details } },
+  ]);
+  assert.deepEqual(first(messages, 'tool_result'), {
+    kind: 'tool_result', toolId: 'terminal-call', content: '', isError: false, isFinal: false, toolUseResult: details,
+  });
+});
+
+test('a background tool update keeps its latest structured result after tool_execution_end', () => {
+  const running = { async: { state: 'running', jobId: 'job-1', type: 'bash' } };
+  const completed = { async: { state: 'completed', jobId: 'job-1', type: 'bash' } };
+  const { messages } = forward([
+    { type: 'tool_execution_end', toolCallId: 'bg-1', toolName: 'bash', result: { content: [{ type: 'text', text: 'Background job started' }], details: running } },
+    { type: 'tool_execution_update', toolCallId: 'bg-1', partialResult: { content: [{ type: 'text', text: 'done' }], details: completed } },
+  ]);
+  const result = all(messages, 'tool_result').at(-1);
+  assert.equal(result?.toolId, 'bg-1');
+  assert.equal(result?.content, 'done');
+  assert.deepEqual(result?.toolUseResult, completed);
+});
+
+test('tool_execution_update preserves explicit errors on the SDK result envelope', () => {
+  for (const content of [[], [{ type: 'text', text: 'Partial execution failed' }]]) {
+    const { messages } = forward([
+      { type: 'tool_execution_update', toolCallId: 'failed', partialResult: { content, isError: true } },
+    ]);
+    const result = first(messages, 'tool_result');
+    assert.ok(result, 'an error-only update still reaches the app');
+    assert.equal(result.isError, true);
+    assert.equal(result.isFinal, false, 'an error update does not invent a terminal event');
+  }
+});
+
 test('a failed turn forwards the provider reason instead of the fixed string', () => {
   const { messages, state } = forward([
     { type: 'message_end', message: { role: 'assistant', stopReason: 'error', errorMessage: 'context window exceeded', content: [] } },

--- a/server/gjc-bun-sdk-events.ts
+++ b/server/gjc-bun-sdk-events.ts
@@ -268,11 +268,16 @@ export function forwardSdkEvent(
     case 'tool_execution_update': {
       // Streaming tool output (and a backgrounded job's real result, which only
       // ever arrives here) otherwise leaves the card frozen on its start state.
-      // The payload field is `partialResult`, and an in-flight update carries no
-      // error flag. Results are keyed by `toolId`, so each update supersedes the
-      // last.
+      // The event has no error flag, but its AgentToolResult envelope can carry
+      // one as well as structured details, even before stdout exists. Results
+      // are keyed by `toolId`, so each update supersedes the last.
       const content = stringifyToolOutput(event.partialResult);
-      if (content) writer.send({ kind: 'tool_result', toolId: str(event.toolCallId), content, isError: false, isFinal: false });
+      const details = toolResultDetails(event.partialResult);
+      const isError = object(event.partialResult) && event.partialResult.isError === true;
+      if (content || details !== undefined || isError) writer.send({
+        kind: 'tool_result', toolId: str(event.toolCallId), content, isError, isFinal: false,
+        ...(details === undefined ? {} : { toolUseResult: details }),
+      });
       return;
     }
     case 'tool_execution_end': {

--- a/server/gjc-engine-manifest.json
+++ b/server/gjc-engine-manifest.json
@@ -52,6 +52,7 @@
     "server/gjc-delegation-executor.bun.test.ts",
     "server/gjc-export-path.test.ts",
     "server/gjc-goal-session.bun.test.ts",
+    "server/gjc-goal-session.test.ts",
     "server/gjc-goal-protocol.test.ts",
     "server/gjc-permission-policy.test.ts",
     "server/gjc-sdk-bridge.test.ts",

--- a/server/gjc-goal-session.test.ts
+++ b/server/gjc-goal-session.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { GJC_GOAL_RUN_LIMIT_MS, GJC_GOAL_TURN_LIMIT, type GjcGoalOperation, type GjcGoalState } from '../shared/gjc-goal.js';
+
+import { GjcGoalSession, readPersistedGjcGoal } from './gjc-goal-session.js';
+
+/** Only the public goal lifecycle surface; no SDK, skill discovery or provider calls. */
+async function fixture() {
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), 'gajae-goal-limits-')));
+  let state: GjcGoalState | undefined;
+  let nextId = 0;
+  let stops = 0;
+  let aborts = 0;
+  let persisted: GjcGoalState | undefined;
+  const entries: ReturnType<ConstructorParameters<typeof GjcGoalSession>[1]['getBranch']> = [];
+  const manager = {
+    getCwd: () => cwd,
+    getBranch: () => entries,
+    appendCustomEntry: (customType: string, data: unknown) => { entries.push({ type: 'custom', customType, data }); },
+    flush: async () => { persisted = structuredClone(readPersistedGjcGoal(manager).state); },
+  };
+  const session = {
+    getGoalModeState: () => state,
+    setGoalModeState: (value: GjcGoalState | undefined) => { state = value; },
+    operateGoal: async (operation: GjcGoalOperation) => {
+      if (operation === 'get') return state;
+      if (operation === 'create') {
+        state = { enabled: true, mode: 'active', goal: {
+          id: `goal-${++nextId}`, objective: 'Bounded ordinary work', status: 'active',
+          tokensUsed: 0, timeUsedSeconds: 0, createdAt: Date.now(), updatedAt: Date.now(),
+        } };
+      } else {
+        assert.ok(state);
+        const status = operation === 'resume' ? 'active' : operation === 'pause' ? 'paused' : 'complete';
+        state = { ...state, enabled: status === 'active', mode: status === 'complete' ? 'exiting' : 'active', goal: { ...state.goal, status } };
+      }
+      entries.push({ type: 'mode_change', mode: state.goal.status === 'paused' ? 'goal_paused' : 'goal', data: { goal: state.goal } });
+      goals.onEvent({ type: 'goal_updated', goal: state.goal, state });
+      return state;
+    },
+    abort: async () => { aborts++; },
+  };
+  const goals = new GjcGoalSession(session, manager, { appSessionId: 'app', owner: 'number:1', cwd }, 'run', () => {}, async () => {
+    stops++;
+    await goals.stop();
+  });
+  await goals.restore();
+  return {
+    goals, stops: () => stops, aborts: () => aborts, persisted: () => persisted,
+    tool: (operation: GjcGoalOperation) => goals.invokeTool(operation, () => session.operateGoal(operation)),
+    close: async () => { await goals.dispose(); await rm(cwd, { recursive: true, force: true }); },
+  };
+}
+
+test('ordinary goal pause/resume retains the original elapsed-time deadline', async (t) => {
+  t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 0 });
+  const f = await fixture();
+  try {
+    await f.tool('create');
+    t.mock.timers.tick(GJC_GOAL_RUN_LIMIT_MS - 1000);
+    await f.tool('pause');
+    t.mock.timers.tick(500);
+    await f.tool('resume');
+    t.mock.timers.tick(499);
+    assert.equal(f.stops(), 0);
+    t.mock.timers.tick(1);
+    assert.equal(f.stops(), 1, 'resume cannot buy a new run budget');
+    await f.goals.stop();
+    assert.equal(f.aborts(), 1);
+    assert.equal(f.persisted()?.goal.status, 'paused');
+    assert.equal(f.persisted()?.enabled, false);
+    await assert.rejects(f.tool('resume'), /app goal controls/);
+  } finally { await f.close(); }
+});
+
+test('ordinary replacement goals share the elapsed-time budget and cannot revive an expired run', async (t) => {
+  t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 0 });
+  const f = await fixture();
+  try {
+    await f.tool('create');
+    const originalId = f.goals.snapshot().goal!.id;
+    t.mock.timers.tick(GJC_GOAL_RUN_LIMIT_MS - 1);
+    await f.tool('complete');
+    t.mock.timers.tick(1);
+    assert.equal(f.stops(), 0, 'completing the goal cancels its active timer');
+    await f.tool('create');
+    assert.notEqual(f.goals.snapshot().goal!.id, originalId);
+    assert.equal(f.stops(), 1, 'a replacement cannot renew an exhausted run');
+    await f.goals.stop();
+    assert.equal(f.persisted()?.goal.status, 'paused');
+    assert.equal(f.goals.snapshot().canControl, false);
+  } finally { await f.close(); }
+});
+
+test('ordinary goal turn limits survive pause/resume and replacement and stop exactly once', async () => {
+  const f = await fixture();
+  try {
+    await f.tool('create');
+    for (let i = 0; i < GJC_GOAL_TURN_LIMIT - 2; i++) f.goals.onEvent({ type: 'turn_end' });
+    await f.tool('pause');
+    for (let i = 0; i < GJC_GOAL_TURN_LIMIT; i++) f.goals.onEvent({ type: 'turn_end' });
+    assert.equal(f.stops(), 0, 'paused work does not consume autonomous turns');
+    await f.tool('resume');
+    f.goals.onEvent({ type: 'turn_end' });
+    await f.tool('complete');
+    await f.tool('create');
+    assert.equal(f.stops(), 0);
+    f.goals.onEvent({ type: 'turn_end' });
+    assert.equal(f.stops(), 1, 'the final available turn stops the whole run');
+    f.goals.onEvent({ type: 'turn_end' });
+    await f.goals.stop();
+    assert.equal(f.stops(), 1);
+    assert.equal(f.aborts(), 1);
+    assert.equal(f.persisted()?.goal.status, 'paused');
+  } finally { await f.close(); }
+});

--- a/server/gjc-sdk-contract.bun.test.ts
+++ b/server/gjc-sdk-contract.bun.test.ts
@@ -466,6 +466,45 @@ test('golden protocol order: session, stream, tool, ask, usage, terminal, respon
   } finally { await f.close(); }
 });
 
+test('streaming tool metadata and errors survive the app worker protocol', async () => {
+  const f = await fixture('astra', undefined, { id: 'astra', provider: 'contract-provider' });
+  const run = f.host.handle(request('session.start', 'tool-updates', {
+    message: 'Offline tool event delivery', options: { ...f.options, modelId: 'astra', effort: 'xhigh' },
+  }));
+  try {
+    const session = await firstSession(f.sessions);
+    await session.promptStarted.promise;
+    const details = { terminalId: 'terminal-1' };
+    session.emit({ type: 'tool_execution_start', toolCallId: 'call-1', toolName: 'bash', args: { command: 'pwd' } });
+    session.emit({ type: 'tool_execution_update', toolCallId: 'call-1', partialResult: { content: [], details } });
+    session.emit({ type: 'tool_execution_update', toolCallId: 'call-1', partialResult: {
+      content: [{ type: 'text', text: 'Partial execution failed' }], details, isError: true,
+    } });
+    session.emit({ type: 'tool_execution_end', toolCallId: 'call-1', toolName: 'bash', result: {
+      content: [{ type: 'text', text: 'Execution failed' }], details,
+    }, isError: true });
+    session.complete();
+    await run;
+    const messages = f.frames.map((frame) => parseGjcWorkerFrame(JSON.stringify(frame)))
+      .flatMap((frame) => frame.kind === 'event' ? [frame.payload.message as Record<string, unknown> | undefined] : []);
+    const results = messages.filter((message) => message?.kind === 'tool_result');
+    assert.equal(results.length, 3);
+    assert.deepEqual(results.map((result) => ({
+      toolId: result!.toolId, content: result!.content, isError: result!.isError,
+      isFinal: result!.isFinal, toolUseResult: result!.toolUseResult,
+    })), [
+      { toolId: 'call-1', content: '', isError: false, isFinal: false, toolUseResult: details },
+      { toolId: 'call-1', content: 'Partial execution failed', isError: true, isFinal: false, toolUseResult: details },
+      { toolId: 'call-1', content: 'Execution failed', isError: true, isFinal: true, toolUseResult: details },
+    ]);
+    assert.equal((response(f.frames, 'tool-updates').payload as { ok: boolean }).ok, true);
+  } finally {
+    f.sessions.forEach((session) => session.complete());
+    await run;
+    await f.close();
+  }
+});
+
 test('advertised GJC builtins execute in the SDK worker without becoming model prompts', async () => {
   const f = await fixture(
     'contract-model',

--- a/shared/productIdentity.js
+++ b/shared/productIdentity.js
@@ -1,6 +1,7 @@
 export const PRODUCT_NAME = 'Gajae Code App';
 export const PRODUCT_TOKEN = 'gajae-app';
 export const PACKAGE_NAME = PRODUCT_TOKEN;
+export const SERVER_PACKAGE_NAME = `${PACKAGE_NAME}-server`;
 export const CLI_NAME = PRODUCT_TOKEN;
 export const DATA_ROOT = '~/.gajae-app';
 export const SYSTEMD_SERVICE_NAME = 'gajae-app.service';

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "gajae-app-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "fs2",
  "getrandom 0.2.17",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gajae-app-desktop"
-version = "0.2.2"
+version = "0.2.3"
 description = "Gajae Code App desktop shell"
 license = "MIT"
 authors = ["Gajae Code App contributors"]

--- a/src-tauri/src/desktop_origin.rs
+++ b/src-tauri/src/desktop_origin.rs
@@ -103,20 +103,18 @@ mod tests {
     }
 
     #[test]
-    fn first_verified_port_is_reused_after_restart() {
+    fn verified_port_persists_across_profile_reload() {
         let directory = Temp::new();
         let first = DesktopOrigin::load(directory.0.clone()).unwrap();
         assert_eq!(first.requested_port(), 0);
         assert!(!directory.0.exists());
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
+        // The supervisor supplies this only after its PID/health handshake.
+        // Socket release/rebind belongs to the installed-app lifecycle drill:
+        // another parallel test may acquire a port immediately after close.
+        let port = 49152;
         first.persist_verified_port(port).unwrap();
         let next = DesktopOrigin::load(directory.0.clone()).unwrap();
         assert_eq!(next.requested_port(), port);
-        assert!(std::net::TcpListener::bind(("127.0.0.1", next.requested_port())).is_err());
-        drop(listener);
-        let restarted = std::net::TcpListener::bind(("127.0.0.1", next.requested_port())).unwrap();
-        assert_eq!(restarted.local_addr().unwrap().port(), port);
         next.persist_verified_port(port).unwrap();
         assert!(next
             .persist_verified_port(if port == 65535 { port - 1 } else { port + 1 })

--- a/src-tauri/src/desktop_origin.rs
+++ b/src-tauri/src/desktop_origin.rs
@@ -1,0 +1,153 @@
+//! Keep the webview origin stable across launches so UI preferences survive.
+//! The first port is OS-assigned; only a verified owned sidecar can persist it.
+use std::{fs, io::Write, path::PathBuf};
+
+#[derive(Debug)]
+pub(crate) struct DesktopOrigin {
+    file: PathBuf,
+    port: u16,
+}
+
+impl DesktopOrigin {
+    pub(crate) fn load(directory: PathBuf) -> Result<Self, String> {
+        let file = directory.join("desktop-port");
+        let port = match fs::symlink_metadata(&file) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(error) => return Err(format!("Could not read desktop origin: {error}")),
+            Ok(metadata) => {
+                if !metadata.file_type().is_file() || metadata.len() > 6 {
+                    return Err("Desktop port must be a small regular file.".into());
+                }
+                let text = fs::read_to_string(&file).map_err(|error| error.to_string())?;
+                text.trim()
+                    .parse::<u16>()
+                    .ok()
+                    .filter(|port| *port >= 1024)
+                    .ok_or("Desktop port is invalid; refusing to change the stored origin.")?
+            }
+        };
+        Ok(Self { file, port })
+    }
+
+    pub(crate) fn requested_port(&self) -> u16 {
+        self.port
+    }
+
+    pub(crate) fn persist_verified_port(&self, port: u16) -> Result<(), String> {
+        if port < 1024 || (self.port != 0 && self.port != port) {
+            return Err("The verified desktop server changed its assigned origin.".into());
+        }
+        if self.port != 0 {
+            return Ok(());
+        }
+        let parent = self
+            .file
+            .parent()
+            .ok_or("Desktop origin directory is missing.")?;
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        builder
+            .create(parent)
+            .map_err(|error| format!("Could not create desktop origin directory: {error}"))?;
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = match options.open(&self.file) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                return if Self::load(parent.to_path_buf())?.port == port {
+                    Ok(())
+                } else {
+                    Err("Desktop origin changed during startup; refusing to overwrite it.".into())
+                };
+            }
+            Err(error) => return Err(format!("Could not preserve desktop origin: {error}")),
+        };
+        if let Err(error) = writeln!(file, "{port}").and_then(|()| file.sync_all()) {
+            drop(file);
+            let _ = fs::remove_file(&self.file);
+            return Err(format!("Could not preserve desktop origin: {error}"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct Temp(PathBuf);
+    impl Temp {
+        fn new() -> Self {
+            let mut id = [0; 8];
+            getrandom::getrandom(&mut id).unwrap();
+            Self(std::env::temp_dir().join(format!(
+                "gajae-origin-{}-{:x}",
+                std::process::id(),
+                u64::from_ne_bytes(id)
+            )))
+        }
+    }
+    impl Drop for Temp {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn first_verified_port_is_reused_after_restart() {
+        let directory = Temp::new();
+        let first = DesktopOrigin::load(directory.0.clone()).unwrap();
+        assert_eq!(first.requested_port(), 0);
+        assert!(!directory.0.exists());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        first.persist_verified_port(port).unwrap();
+        let next = DesktopOrigin::load(directory.0.clone()).unwrap();
+        assert_eq!(next.requested_port(), port);
+        assert!(std::net::TcpListener::bind(("127.0.0.1", next.requested_port())).is_err());
+        drop(listener);
+        let restarted = std::net::TcpListener::bind(("127.0.0.1", next.requested_port())).unwrap();
+        assert_eq!(restarted.local_addr().unwrap().port(), port);
+        next.persist_verified_port(port).unwrap();
+        assert!(next
+            .persist_verified_port(if port == 65535 { port - 1 } else { port + 1 })
+            .is_err());
+    }
+
+    #[test]
+    fn rejects_foreign_invalid_and_conflicting_port_records() {
+        let directory = Temp::new();
+        fs::create_dir(&directory.0).unwrap();
+        let file = directory.0.join("desktop-port");
+        for text in ["0", "80", "65536", "bad", "1234\n5678"] {
+            fs::write(&file, text).unwrap();
+            assert!(DesktopOrigin::load(directory.0.clone()).is_err());
+            assert_eq!(fs::read_to_string(&file).unwrap(), text);
+        }
+        fs::remove_file(&file).unwrap();
+        let first = DesktopOrigin::load(directory.0.clone()).unwrap();
+        assert!(first.persist_verified_port(0).is_err());
+        assert!(!file.exists());
+        fs::write(&file, "49152\n").unwrap();
+        assert!(first.persist_verified_port(49153).is_err());
+        assert_eq!(fs::read_to_string(&file).unwrap(), "49152\n");
+        #[cfg(unix)]
+        {
+            fs::remove_file(&file).unwrap();
+            let target = directory.0.join("foreign");
+            fs::write(&target, "49153\n").unwrap();
+            std::os::unix::fs::symlink(&target, &file).unwrap();
+            assert!(DesktopOrigin::load(directory.0.clone()).is_err());
+            assert!(first.persist_verified_port(49153).is_err());
+        }
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -244,12 +244,13 @@ fn main() {
     }
     let context = tauri::generate_context!();
     #[cfg(target_os = "macos")]
-    let context = {
+    let (context, qa_windows) = {
         let mut context = context;
-        if let Some(profile) = &qa_profile {
-            profile.configure(context.config_mut());
-        }
-        context
+        let windows = qa_profile
+            .as_ref()
+            .map(|profile| profile.configure(context.config_mut()))
+            .unwrap_or_default();
+        (context, windows)
     };
 
     #[cfg(target_os = "linux")]
@@ -280,13 +281,14 @@ fn main() {
             #[cfg(not(target_os = "linux"))]
             let lock_result = {
                 #[cfg(target_os = "macos")]
-                if let Some(profile) = &qa_profile {
-                    acquire_single_instance_lock_at(&profile.lock_path())
+                if qa_profile.is_some() {
+                    // QaProfile already owns its lock, before window creation.
+                    Ok(None)
                 } else {
-                    acquire_single_instance_lock()
+                    acquire_single_instance_lock().map(Some)
                 }
                 #[cfg(not(target_os = "macos"))]
-                acquire_single_instance_lock()
+                acquire_single_instance_lock().map(Some)
             };
             #[cfg(not(target_os = "linux"))]
             let lock = match lock_result {
@@ -297,7 +299,9 @@ fn main() {
                 }
             };
             #[cfg(not(target_os = "linux"))]
-            app.manage(lock);
+            if let Some(lock) = lock {
+                app.manage(lock);
+            }
             #[cfg(target_os = "macos")]
             if let Some(profile) = qa_profile {
                 app.manage(profile);
@@ -305,6 +309,10 @@ fn main() {
             app.manage(navigation::LoopbackOrigin::default());
             app.manage(lifecycle::SidecarLifecycle::default());
             app.manage(supervisor::RecoveryScreen::default());
+            #[cfg(target_os = "macos")]
+            if let Some(profile) = app.try_state::<qa_profile::QaProfile>() {
+                profile.create_windows(app, &qa_windows)?;
+            }
             #[cfg(target_os = "linux")]
             {
                 app.manage(StartupDeepLinks::new(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use std::fs::OpenOptions;
 use fs2::FileExt;
 use tauri::Manager;
 
+mod desktop_origin;
 #[cfg(target_os = "linux")]
 mod instance;
 mod lifecycle;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,8 @@ use tauri::Manager;
 mod instance;
 mod lifecycle;
 mod navigation;
+#[cfg(any(target_os = "macos", test))]
+mod qa_profile;
 mod supervisor;
 
 #[cfg(not(target_os = "linux"))]
@@ -216,6 +218,40 @@ fn retry_desktop_server(app: tauri::AppHandle) {
 fn main() {
     use tauri_plugin_deep_link::DeepLinkExt;
 
+    #[cfg(target_os = "macos")]
+    let qa_profile = (|| -> Result<Option<qa_profile::QaProfile>, String> {
+        let Some(root) = qa_profile::requested_root(std::env::args().skip(1))? else {
+            return Ok(None);
+        };
+        let version = std::process::Command::new("/usr/bin/sw_vers")
+            .arg("-productVersion")
+            .output()
+            .map_err(|error| format!("Could not check macOS QA support: {error}"))?;
+        if !version.status.success() {
+            return Err("Could not check macOS QA support.".into());
+        }
+        qa_profile::require_supported_os(&String::from_utf8_lossy(&version.stdout))?;
+        qa_profile::QaProfile::open(&root).map(Some)
+    })()
+    .unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(1);
+    });
+    #[cfg(not(target_os = "macos"))]
+    if std::env::args().any(|arg| arg == "--qa-profile" || arg.starts_with("--qa-profile=")) {
+        eprintln!("--qa-profile is currently supported only on macOS 14 or newer.");
+        std::process::exit(1);
+    }
+    let context = tauri::generate_context!();
+    #[cfg(target_os = "macos")]
+    let context = {
+        let mut context = context;
+        if let Some(profile) = &qa_profile {
+            profile.configure(context.config_mut());
+        }
+        context
+    };
+
     #[cfg(target_os = "linux")]
     let (instance, activation) = {
         let activation = instance::Activation::from_args(std::env::args().skip(1));
@@ -242,7 +278,18 @@ fn main() {
             // SIGABRT -> crash-reporter dialog), so exit cleanly instead;
             // macOS LaunchServices focuses the running instance on reopen.
             #[cfg(not(target_os = "linux"))]
-            let lock = match acquire_single_instance_lock() {
+            let lock_result = {
+                #[cfg(target_os = "macos")]
+                if let Some(profile) = &qa_profile {
+                    acquire_single_instance_lock_at(&profile.lock_path())
+                } else {
+                    acquire_single_instance_lock()
+                }
+                #[cfg(not(target_os = "macos"))]
+                acquire_single_instance_lock()
+            };
+            #[cfg(not(target_os = "linux"))]
+            let lock = match lock_result {
                 Ok(lock) => lock,
                 Err(message) => {
                     eprintln!("{message}");
@@ -251,6 +298,10 @@ fn main() {
             };
             #[cfg(not(target_os = "linux"))]
             app.manage(lock);
+            #[cfg(target_os = "macos")]
+            if let Some(profile) = qa_profile {
+                app.manage(profile);
+            }
             app.manage(navigation::LoopbackOrigin::default());
             app.manage(lifecycle::SidecarLifecycle::default());
             app.manage(supervisor::RecoveryScreen::default());
@@ -312,7 +363,7 @@ fn main() {
             Ok(())
         });
     let app = builder
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("failed to run Gajae Code App desktop shell");
     app.run(
         |app: &tauri::AppHandle<tauri::Wry>, event: tauri::RunEvent| match event {

--- a/src-tauri/src/qa_profile.rs
+++ b/src-tauri/src/qa_profile.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+use tauri::utils::config::{Config, WindowConfig};
 
 const MANIFEST: &str = "desktop-qa-profile.json";
 
@@ -23,6 +24,9 @@ struct Manifest {
 pub(crate) struct QaProfile {
     root: PathBuf,
     webkit_store: [u8; 16],
+    // Own the profile before changing directories or constructing any webview.
+    // Tauri creates configured windows before invoking the app setup callback.
+    _lock: fs::File,
 }
 
 pub(crate) fn requested_root(
@@ -92,8 +96,11 @@ fn private_directory(path: &Path) -> Result<(), String> {
 
 impl QaProfile {
     pub(crate) fn open(path: &Path) -> Result<Self, String> {
+        // A trailing slash or `/.` makes lstat follow the final symlink on
+        // macOS. Remove those lexical suffixes before inspecting the root.
+        let path: PathBuf = path.components().collect();
         if !path.is_absolute()
-            || fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
+            || fs::symlink_metadata(&path).is_ok_and(|m| m.file_type().is_symlink())
         {
             return Err("QA root must be an absolute non-symlink directory.".into());
         }
@@ -101,7 +108,7 @@ impl QaProfile {
         // root-bound manifest. Never adopt an existing home or project.
         if path.exists()
             && !path.join(MANIFEST).exists()
-            && fs::read_dir(path)
+            && fs::read_dir(&path)
                 .map_err(|e| e.to_string())?
                 .next()
                 .is_some()
@@ -109,25 +116,48 @@ impl QaProfile {
             return Err("QA root must be empty or an existing desktop QA profile.".into());
         }
         if !path.exists() {
-            private_directory(path)?;
+            private_directory(&path)?;
         }
         let root = path.canonicalize().map_err(|error| error.to_string())?;
         let manifest_path = root.join(MANIFEST);
         if fs::symlink_metadata(&manifest_path).is_ok_and(|m| m.file_type().is_symlink()) {
             return Err("QA manifest cannot be a symlink.".into());
         }
-        let manifest: Manifest = if manifest_path.exists() {
-            if fs::metadata(&manifest_path)
-                .map_err(|error| error.to_string())?
-                .len()
-                > 4096
-            {
-                return Err("Invalid desktop QA manifest size.".into());
+        let manifest: Option<Manifest> = if manifest_path.exists() {
+            let metadata = fs::metadata(&manifest_path).map_err(|error| error.to_string())?;
+            if !metadata.is_file() || metadata.len() > 4096 {
+                return Err("QA manifest must be a regular file of at most 4096 bytes.".into());
             }
             let bytes = fs::read(&manifest_path).map_err(|error| error.to_string())?;
-            serde_json::from_slice(&bytes).map_err(|_| "Invalid desktop QA manifest.")?
+            let manifest: Manifest =
+                serde_json::from_slice(&bytes).map_err(|_| "Invalid desktop QA manifest.")?;
+            if manifest.version != 1 || manifest.root != root || manifest.webkit_store == [0; 16] {
+                return Err("Desktop QA manifest does not belong to this directory.".into());
+            }
+            Some(manifest)
         } else {
-            private_directory(&root)?;
+            None
+        };
+        // Validate ownership before creating a lock in an existing directory;
+        // then acquire it before either profile initialization or WebKit use.
+        let lock_path = root.join("desktop.lock");
+        if fs::symlink_metadata(&lock_path).is_ok_and(|metadata| !metadata.file_type().is_file()) {
+            return Err("QA instance lock must be a regular non-symlink file.".into());
+        }
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(false);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let lock = options.open(lock_path).map_err(|error| error.to_string())?;
+        fs2::FileExt::try_lock_exclusive(&lock)
+            .map_err(|_| "This desktop QA profile is already in use.".to_owned())?;
+        private_directory(&root)?;
+        let manifest = if let Some(manifest) = manifest {
+            manifest
+        } else {
             let mut webkit_store = [0; 16];
             getrandom::getrandom(&mut webkit_store).map_err(|error| error.to_string())?;
             webkit_store[6] = (webkit_store[6] & 0x0f) | 0x40;
@@ -152,10 +182,6 @@ impl QaProfile {
             file.sync_all().map_err(|error| error.to_string())?;
             manifest
         };
-        if manifest.version != 1 || manifest.root != root || manifest.webkit_store == [0; 16] {
-            return Err("Desktop QA manifest does not belong to this directory.".into());
-        }
-        private_directory(&root)?;
         for name in [
             "home",
             "home/.gajae-app",
@@ -178,21 +204,41 @@ impl QaProfile {
         Ok(Self {
             root,
             webkit_store: manifest.webkit_store,
+            _lock: lock,
         })
     }
 
     pub(crate) fn home(&self) -> PathBuf {
         self.root.join("home")
     }
-    pub(crate) fn lock_path(&self) -> PathBuf {
-        self.root.join("desktop.lock")
-    }
 
-    pub(crate) fn configure(&self, config: &mut tauri::utils::config::Config) {
+    pub(crate) fn configure(&self, config: &mut Config) -> Vec<WindowConfig> {
+        let mut windows = Vec::new();
         for window in &mut config.app.windows {
             window.data_store_identifier = Some(self.webkit_store);
             window.title = format!("{} — QA", window.title);
+            if window.create {
+                windows.push(window.clone());
+            }
+            // tauri-runtime 2.7 drops the UUID in WindowConfig ->
+            // WebviewAttributes. Build QA windows with the explicit setter.
+            window.create = false;
         }
+        windows
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn create_windows(
+        &self,
+        app: &tauri::App,
+        windows: &[WindowConfig],
+    ) -> tauri::Result<()> {
+        for window in windows {
+            tauri::WebviewWindowBuilder::from_config(app, window)?
+                .data_store_identifier(self.webkit_store)
+                .build()?;
+        }
+        Ok(())
     }
 
     pub(crate) fn environment(&self) -> BTreeMap<String, String> {
@@ -277,10 +323,13 @@ mod tests {
         let a = Temp::new();
         let b = Temp::new();
         let first = QaProfile::open(&a.0).unwrap();
+        let store = first.webkit_store;
+        drop(first);
         let again = QaProfile::open(&a.0).unwrap();
         let other = QaProfile::open(&b.0).unwrap();
-        assert_eq!(first.webkit_store, again.webkit_store);
-        assert_ne!(first.webkit_store, other.webkit_store);
+        assert_eq!(store, again.webkit_store);
+        assert_ne!(store, other.webkit_store);
+        drop(other);
         fs::copy(a.0.join(MANIFEST), b.0.join(MANIFEST)).unwrap();
         assert!(QaProfile::open(&b.0).is_err());
     }
@@ -315,7 +364,8 @@ mod tests {
             .app
             .windows
             .push(tauri::utils::config::WindowConfig::default());
-        profile.configure(&mut config);
+        let windows = profile.configure(&mut config);
+        assert_eq!(windows.len(), 1);
         assert!(config
             .app
             .windows
@@ -333,6 +383,127 @@ mod tests {
         assert_eq!(environment["HOME"], profile.home().to_string_lossy());
         assert!(!environment.contains_key("OPENAI_API_KEY"));
         assert!(!environment.contains_key("NODE_OPTIONS"));
-        assert!(profile.lock_path().starts_with(&profile.root));
+        assert!(profile.root.join("desktop.lock").is_file());
+    }
+
+    #[test]
+    fn qa_windows_cannot_be_created_by_tauris_config_conversion() {
+        let root = Temp::new();
+        let profile = QaProfile::open(&root.0).unwrap();
+        let mut config = tauri::utils::config::Config::default();
+        config.app.windows = vec![
+            WindowConfig::default(),
+            WindowConfig {
+                label: "secondary".into(),
+                ..WindowConfig::default()
+            },
+            WindowConfig {
+                label: "deferred".into(),
+                create: false,
+                ..WindowConfig::default()
+            },
+        ];
+        let windows = profile.configure(&mut config);
+        // The pinned runtime drops the UUID in its config conversion. Such
+        // windows must not reach Tauri's automatic window creation path.
+        let attributes = tauri_runtime::webview::WebviewAttributes::from(&config.app.windows[0]);
+        assert_eq!(attributes.data_store_identifier, None);
+        assert!(config.app.windows.iter().all(|window| !window.create));
+        assert_eq!(
+            windows
+                .iter()
+                .map(|window| window.label.as_str())
+                .collect::<Vec<_>>(),
+            ["main", "secondary"]
+        );
+        assert!(windows
+            .iter()
+            .all(|window| window.data_store_identifier == Some(profile.webkit_store)));
+    }
+
+    #[test]
+    fn profile_owns_its_lock_before_configuring_any_windows() {
+        let root = Temp::new();
+        let profile = QaProfile::open(&root.0).unwrap();
+        let manifest = fs::read(root.0.join(MANIFEST)).unwrap();
+        // A contender must not initialize missing paths before discovering the
+        // owner. This directory is only a fixture, with no sidecar running.
+        fs::remove_dir(profile.home().join(".cache")).unwrap();
+        assert!(QaProfile::open(&root.0).is_err());
+        assert!(!profile.home().join(".cache").exists());
+        assert_eq!(fs::read(root.0.join(MANIFEST)).unwrap(), manifest);
+        let store = profile.webkit_store;
+        drop(profile);
+        assert_eq!(QaProfile::open(&root.0).unwrap().webkit_store, store);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_roots_with_trailing_separators_without_mutating_target() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+        for suffix in ["/", "/."] {
+            let parent = Temp::new();
+            fs::create_dir(&parent.0).unwrap();
+            let target = parent.0.join("user-directory");
+            fs::create_dir(&target).unwrap();
+            fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
+            let link = parent.0.join("alias");
+            symlink(&target, &link).unwrap();
+            let alias = PathBuf::from(format!("{}{suffix}", link.display()));
+            assert!(QaProfile::open(&alias).is_err(), "{alias:?}");
+            assert_eq!(fs::read_dir(&target).unwrap().count(), 0);
+            assert_eq!(
+                fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_manifest_does_not_change_permissions_or_create_a_lock() {
+        use std::os::unix::fs::PermissionsExt;
+        for contents in [
+            "{}",
+            "not json",
+            "{\"version\":1,\"root\":\"/wrong\",\"webkit_store\":[0]}",
+        ] {
+            let root = Temp::new();
+            fs::create_dir(&root.0).unwrap();
+            fs::set_permissions(&root.0, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::write(root.0.join(MANIFEST), contents).unwrap();
+            assert!(QaProfile::open(&root.0).is_err());
+            assert_eq!(fs::read_dir(&root.0).unwrap().count(), 1);
+            assert_eq!(
+                fs::metadata(&root.0).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+            assert_eq!(fs::read_to_string(root.0.join(MANIFEST)).unwrap(), contents);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_non_regular_manifest_and_symlinked_lock() {
+        let root = Temp::new();
+        fs::create_dir(&root.0).unwrap();
+        let manifest = root.0.join(MANIFEST);
+        assert!(std::process::Command::new("/usr/bin/mkfifo")
+            .arg(&manifest)
+            .status()
+            .unwrap()
+            .success());
+        assert!(QaProfile::open(&root.0).is_err());
+        assert_eq!(fs::read_dir(&root.0).unwrap().count(), 1);
+        fs::remove_file(manifest).unwrap();
+
+        drop(QaProfile::open(&root.0).unwrap());
+        let lock = root.0.join("desktop.lock");
+        fs::remove_file(&lock).unwrap();
+        let target = root.0.join("user-file");
+        fs::write(&target, "keep").unwrap();
+        std::os::unix::fs::symlink(&target, lock).unwrap();
+        assert!(QaProfile::open(&root.0).is_err());
+        assert_eq!(fs::read_to_string(target).unwrap(), "keep");
     }
 }

--- a/src-tauri/src/qa_profile.rs
+++ b/src-tauri/src/qa_profile.rs
@@ -1,0 +1,338 @@
+//! Explicit, credential-free profiles for installed-app acceptance.
+//! A HOME override alone does not isolate WKWebView's default data store.
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+const MANIFEST: &str = "desktop-qa-profile.json";
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    version: u8,
+    root: PathBuf,
+    webkit_store: [u8; 16],
+}
+
+#[derive(Debug)]
+pub(crate) struct QaProfile {
+    root: PathBuf,
+    webkit_store: [u8; 16],
+}
+
+pub(crate) fn requested_root(
+    args: impl IntoIterator<Item = String>,
+) -> Result<Option<PathBuf>, String> {
+    let mut args = args.into_iter();
+    let mut root = None;
+    while let Some(arg) = args.next() {
+        if arg == "--qa-profile" {
+            if root.is_some() {
+                return Err("Specify --qa-profile once.".into());
+            }
+            let path = args
+                .next()
+                .filter(|value| !value.starts_with('-'))
+                .ok_or("--qa-profile requires an absolute directory.")?;
+            if !Path::new(&path).is_absolute() {
+                return Err("--qa-profile requires an absolute directory.".into());
+            }
+            root = Some(PathBuf::from(path));
+        } else if arg.starts_with("--qa-profile=") {
+            return Err("Use --qa-profile /absolute/directory.".into());
+        }
+    }
+    Ok(root)
+}
+
+pub(crate) fn require_supported_os(version: &str) -> Result<(), String> {
+    let major = version
+        .trim()
+        .split('.')
+        .next()
+        .and_then(|part| part.parse::<u32>().ok());
+    if major.is_some_and(|major| major >= 14) {
+        Ok(())
+    } else {
+        Err(
+            "Isolated desktop QA requires macOS 14 or newer; refusing the default WebKit store."
+                .into(),
+        )
+    }
+}
+
+fn private_directory(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(format!(
+                "QA path must be a real directory: {}",
+                path.display()
+            ))
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir(path)
+                .map_err(|error| format!("Could not create QA directory: {error}"))?;
+        }
+        Err(error) => return Err(format!("Could not inspect QA directory: {error}")),
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("Could not protect QA directory: {error}"))?;
+    }
+    Ok(())
+}
+
+impl QaProfile {
+    pub(crate) fn open(path: &Path) -> Result<Self, String> {
+        if !path.is_absolute()
+            || fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
+        {
+            return Err("QA root must be an absolute non-symlink directory.".into());
+        }
+        // An existing directory belongs to QA only if empty or carrying our
+        // root-bound manifest. Never adopt an existing home or project.
+        if path.exists()
+            && !path.join(MANIFEST).exists()
+            && fs::read_dir(path)
+                .map_err(|e| e.to_string())?
+                .next()
+                .is_some()
+        {
+            return Err("QA root must be empty or an existing desktop QA profile.".into());
+        }
+        if !path.exists() {
+            private_directory(path)?;
+        }
+        let root = path.canonicalize().map_err(|error| error.to_string())?;
+        let manifest_path = root.join(MANIFEST);
+        if fs::symlink_metadata(&manifest_path).is_ok_and(|m| m.file_type().is_symlink()) {
+            return Err("QA manifest cannot be a symlink.".into());
+        }
+        let manifest: Manifest = if manifest_path.exists() {
+            if fs::metadata(&manifest_path)
+                .map_err(|error| error.to_string())?
+                .len()
+                > 4096
+            {
+                return Err("Invalid desktop QA manifest size.".into());
+            }
+            let bytes = fs::read(&manifest_path).map_err(|error| error.to_string())?;
+            serde_json::from_slice(&bytes).map_err(|_| "Invalid desktop QA manifest.")?
+        } else {
+            private_directory(&root)?;
+            let mut webkit_store = [0; 16];
+            getrandom::getrandom(&mut webkit_store).map_err(|error| error.to_string())?;
+            webkit_store[6] = (webkit_store[6] & 0x0f) | 0x40;
+            webkit_store[8] = (webkit_store[8] & 0x3f) | 0x80;
+            let manifest = Manifest {
+                version: 1,
+                root: root.clone(),
+                webkit_store,
+            };
+            let mut options = fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut file = options
+                .open(&manifest_path)
+                .map_err(|error| error.to_string())?;
+            file.write_all(&serde_json::to_vec(&manifest).map_err(|error| error.to_string())?)
+                .map_err(|error| error.to_string())?;
+            file.sync_all().map_err(|error| error.to_string())?;
+            manifest
+        };
+        if manifest.version != 1 || manifest.root != root || manifest.webkit_store == [0; 16] {
+            return Err("Desktop QA manifest does not belong to this directory.".into());
+        }
+        private_directory(&root)?;
+        for name in [
+            "home",
+            "home/.gajae-app",
+            "home/.gjc",
+            "home/.gjc/agent",
+            "home/.gjc/live-sessions",
+            "home/.config",
+            "home/.cache",
+            "home/.local",
+            "home/.local/share",
+            "home/.local/state",
+            "workspaces",
+            "tmp",
+            "browser",
+            "browser/profile",
+            "browser/chromium",
+        ] {
+            private_directory(&root.join(name))?;
+        }
+        Ok(Self {
+            root,
+            webkit_store: manifest.webkit_store,
+        })
+    }
+
+    pub(crate) fn home(&self) -> PathBuf {
+        self.root.join("home")
+    }
+    pub(crate) fn lock_path(&self) -> PathBuf {
+        self.root.join("desktop.lock")
+    }
+
+    pub(crate) fn configure(&self, config: &mut tauri::utils::config::Config) {
+        for window in &mut config.app.windows {
+            window.data_store_identifier = Some(self.webkit_store);
+            window.title = format!("{} — QA", window.title);
+        }
+    }
+
+    pub(crate) fn environment(&self) -> BTreeMap<String, String> {
+        let mut result = BTreeMap::from([
+            ("PATH".into(), "/usr/bin:/bin:/usr/sbin:/sbin".into()),
+            ("LANG".into(), "en_US.UTF-8".into()),
+        ]);
+        for (name, relative) in [
+            ("HOME", "home"),
+            ("USERPROFILE", "home"),
+            ("DATABASE_PATH", "home/.gajae-app/auth.db"),
+            ("GJC_CODING_AGENT_DIR", "home/.gjc/agent"),
+            ("GJC_WORKER_AGENT_DIR", "home/.gjc/agent"),
+            ("GJC_LIVE_SESSION_DIR", "home/.gjc/live-sessions"),
+            ("WORKSPACES_ROOT", "workspaces"),
+            ("XDG_CONFIG_HOME", "home/.config"),
+            ("XDG_CACHE_HOME", "home/.cache"),
+            ("XDG_DATA_HOME", "home/.local/share"),
+            ("XDG_STATE_HOME", "home/.local/state"),
+            ("TMPDIR", "tmp"),
+            ("GAJAE_BROWSER_PROFILE_DIR", "browser/profile"),
+            ("GAJAE_BROWSER_CACHE_DIR", "browser/chromium"),
+        ] {
+            result.insert(
+                name.into(),
+                self.root.join(relative).to_string_lossy().into_owned(),
+            );
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct Temp(PathBuf);
+    impl Temp {
+        fn new() -> Self {
+            let mut id = [0; 8];
+            getrandom::getrandom(&mut id).unwrap();
+            let path = std::env::temp_dir().join(format!(
+                "gajae-profile-{}-{:x}",
+                std::process::id(),
+                u64::from_ne_bytes(id)
+            ));
+            Self(path)
+        }
+    }
+    impl Drop for Temp {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn profile_switch_is_explicit_and_unambiguous() {
+        assert_eq!(
+            requested_root(vec!["gajae-app://open/job/test".into()]).unwrap(),
+            None
+        );
+        for args in [
+            vec!["--qa-profile"],
+            vec!["--qa-profile", "relative"],
+            vec!["--qa-profile", "/a", "--qa-profile", "/b"],
+            vec!["--qa-profile=/tmp/a"],
+        ] {
+            assert!(requested_root(args.into_iter().map(str::to_owned)).is_err());
+        }
+        assert_eq!(
+            requested_root(vec!["--qa-profile".into(), "/tmp/qa".into()]).unwrap(),
+            Some(PathBuf::from("/tmp/qa"))
+        );
+        for version in ["13.6.9", "11.0", "", "unknown"] {
+            assert!(require_supported_os(version).is_err());
+        }
+        assert!(require_supported_os("14.0\n").is_ok());
+        assert!(require_supported_os("26.6.2").is_ok());
+    }
+
+    #[test]
+    fn profiles_persist_their_own_webkit_store_and_reject_copied_identity() {
+        let a = Temp::new();
+        let b = Temp::new();
+        let first = QaProfile::open(&a.0).unwrap();
+        let again = QaProfile::open(&a.0).unwrap();
+        let other = QaProfile::open(&b.0).unwrap();
+        assert_eq!(first.webkit_store, again.webkit_store);
+        assert_ne!(first.webkit_store, other.webkit_store);
+        fs::copy(a.0.join(MANIFEST), b.0.join(MANIFEST)).unwrap();
+        assert!(QaProfile::open(&b.0).is_err());
+    }
+
+    #[test]
+    fn refuses_existing_user_data_and_symlinked_paths() {
+        let root = Temp::new();
+        fs::create_dir(&root.0).unwrap();
+        fs::write(root.0.join("user-data"), "keep").unwrap();
+        assert!(QaProfile::open(&root.0).is_err());
+        assert_eq!(
+            fs::read_to_string(root.0.join("user-data")).unwrap(),
+            "keep"
+        );
+        #[cfg(unix)]
+        {
+            let profile = Temp::new();
+            QaProfile::open(&profile.0).unwrap();
+            let home = profile.0.join("home");
+            fs::remove_dir_all(&home).unwrap();
+            std::os::unix::fs::symlink(&root.0, &home).unwrap();
+            assert!(QaProfile::open(&profile.0).is_err());
+        }
+    }
+
+    #[test]
+    fn isolates_every_window_and_server_path_without_inherited_credentials() {
+        let root = Temp::new();
+        let profile = QaProfile::open(&root.0).unwrap();
+        let mut config = tauri::utils::config::Config::default();
+        config
+            .app
+            .windows
+            .push(tauri::utils::config::WindowConfig::default());
+        profile.configure(&mut config);
+        assert!(config
+            .app
+            .windows
+            .iter()
+            .all(
+                |window| window.data_store_identifier == Some(profile.webkit_store)
+                    && window.title.ends_with(" — QA")
+            ));
+        let environment = profile.environment();
+        for (name, value) in &environment {
+            if name != "PATH" && name != "LANG" {
+                assert!(Path::new(value).starts_with(&profile.root), "{name}");
+            }
+        }
+        assert_eq!(environment["HOME"], profile.home().to_string_lossy());
+        assert!(!environment.contains_key("OPENAI_API_KEY"));
+        assert!(!environment.contains_key("NODE_OPTIONS"));
+        assert!(profile.lock_path().starts_with(&profile.root));
+    }
+}

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -428,19 +428,34 @@ pub fn start(app: AppHandle) {
                 .0
                 .lock()
                 .expect("recovery screen lock poisoned") = None;
-            let (events, child) = app
+            let command = app
                 .shell()
                 .sidecar("gajae-app-server")
                 .map_err(|error| format!("could not prepare server sidecar: {error}"))?
-                .arg(entrypoint.to_string_lossy().as_ref())
+                .arg(entrypoint.to_string_lossy().as_ref());
+            #[cfg(target_os = "macos")]
+            let command = if let Some(profile) = app.try_state::<crate::qa_profile::QaProfile>() {
+                if payload.join(".env").exists() {
+                    return Err(
+                        "QA refuses a server payload containing an environment file.".into(),
+                    );
+                }
+                command
+                    .env_clear()
+                    .envs(profile.environment())
+                    .current_dir(profile.home())
+            } else {
+                command.env("HOME", &home).env("PATH", &path)
+            };
+            #[cfg(not(target_os = "macos"))]
+            let command = command.env("HOME", &home).env("PATH", &path);
+            let (events, child) = command
                 .env("HOST", "127.0.0.1")
                 .env("SERVER_PORT", "0")
                 .env("NODE_ENV", "production")
                 .env("GJC_DESKTOP", "1")
                 .env("GJC_DESKTOP_API_KEY", api_key)
                 .env("GJC_DESKTOP_BOOTSTRAP_NONCE", &nonce)
-                .env("HOME", home)
-                .env("PATH", path)
                 .spawn()
                 .map_err(|error| format!("could not start server sidecar: {error}"))?;
             Ok((child.pid(), (events, child)))

--- a/src-tauri/src/supervisor.rs
+++ b/src-tauri/src/supervisor.rs
@@ -398,6 +398,24 @@ pub fn start(app: AppHandle) {
         if lifecycle.is_shutting_down() || lifecycle.has_sidecar() {
             return;
         }
+        let origin_directory = app.path().app_local_data_dir();
+        #[cfg(target_os = "macos")]
+        let origin_directory =
+            if let Some(profile) = app.try_state::<crate::qa_profile::QaProfile>() {
+                Ok(profile.home().join(".gajae-app"))
+            } else {
+                origin_directory
+            };
+        let desktop_origin = match origin_directory
+            .map_err(|error| error.to_string())
+            .and_then(crate::desktop_origin::DesktopOrigin::load)
+        {
+            Ok(origin) => origin,
+            Err(error) => {
+                show_error(&window, &error, true);
+                return;
+            }
+        };
         let payload = match payload_root(&app) {
             Ok(payload) => payload,
             Err(error) => {
@@ -451,7 +469,7 @@ pub fn start(app: AppHandle) {
             let command = command.env("HOME", &home).env("PATH", &path);
             let (events, child) = command
                 .env("HOST", "127.0.0.1")
-                .env("SERVER_PORT", "0")
+                .env("SERVER_PORT", desktop_origin.requested_port().to_string())
                 .env("NODE_ENV", "production")
                 .env("GJC_DESKTOP", "1")
                 .env("GJC_DESKTOP_API_KEY", api_key)
@@ -560,8 +578,11 @@ pub fn start(app: AppHandle) {
                                 if lifecycle.is_shutting_down() {
                                     break;
                                 }
-                                if let Err(error) =
-                                    navigate_and_show(&app, &window, ready_frame.port, &nonce)
+                                if let Err(error) = desktop_origin
+                                    .persist_verified_port(ready_frame.port)
+                                    .and_then(|()| {
+                                        navigate_and_show(&app, &window, ready_frame.port, &nonce)
+                                    })
                                 {
                                     handle_sidecar_failure(
                                         &app, &window, child, events, error, false,

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -132,6 +132,7 @@ function convertRow(message: NormalizedMessage, attachedResult: AttachedResult):
     const toolResult = attachedResult ? {
       content: toolOutputText(attachedResult.content),
       isError: Boolean(attachedResult.isError),
+      isFinal: attachedResult.isFinal,
       toolUseResult: (attachedResult as any).toolUseResult,
       // When the result landed, so a finished turn can say how long it worked.
       timestamp: (attachedResult as { timestamp?: string }).timestamp,
@@ -146,7 +147,7 @@ function convertRow(message: NormalizedMessage, attachedResult: AttachedResult):
       toolResultTruncated: Boolean(message.toolResultTruncated || (attachedResult as { toolResultTruncated?: unknown } | null)?.toolResultTruncated),
       toolResultBytes: message.toolResultBytes ?? (attachedResult as { toolResultBytes?: number } | null)?.toolResultBytes,
       isSubagentContainer: isTask,
-      subagentState: isTask ? { childTools, currentToolIndex: childTools.length ? childTools.length - 1 : -1, isComplete: Boolean(toolResult) } : undefined,
+      subagentState: isTask ? { childTools, currentToolIndex: childTools.length ? childTools.length - 1 : -1, isComplete: Boolean(toolResult && toolResult.isFinal !== false) } : undefined,
       ...common,
     });
     return output;

--- a/src/components/chat/tests/useChatMessages.test.ts
+++ b/src/components/chat/tests/useChatMessages.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import type { NormalizedMessage } from '../../../stores/useSessionStore';
 import { normalizedToChatMessages } from '../hooks/useChatMessages';
+import { isToolCallRunning } from '../utils/toolActivity';
 
 /*
  * The conversion is what the transcript renders from, and the pane's rows
@@ -71,4 +72,19 @@ test('a text row that yields two messages yields the same two next time', () => 
   const second = normalizedToChatMessages([notice]);
   assert.equal(second[0], first[0]);
   assert.equal(second[1], first[1]);
+});
+
+test('partial tool results preserve their running state through chat conversion', () => {
+  for (const toolName of ['bash', 'Task']) {
+    const call = row({ kind: 'tool_use', toolId: 'partial-tool', toolName, toolInput: {} });
+    const partial = row({ kind: 'tool_result', toolId: 'partial-tool', content: '', isError: false, isFinal: false });
+    const running = normalizedToChatMessages([call, partial])[0];
+    assert.equal(running.toolResult?.isFinal, false);
+    assert.equal(isToolCallRunning(running), true);
+    if (toolName === 'Task') assert.equal(running.subagentState?.isComplete, false);
+    const final = row({ kind: 'tool_result', toolId: 'partial-tool', content: '', isError: false, isFinal: true });
+    const finished = normalizedToChatMessages([call, partial, final])[0];
+    assert.equal(isToolCallRunning(finished), false);
+    if (toolName === 'Task') assert.equal(finished.subagentState?.isComplete, true);
+  }
 });

--- a/src/components/chat/tools/ToolRenderer.streaming.test.tsx
+++ b/src/components/chat/tools/ToolRenderer.streaming.test.tsx
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ToolRenderer } from './ToolRenderer';
+
+test('tool cards keep a running badge for metadata-only and nonempty partial results', () => {
+  for (const content of ['', 'Already streamed output']) {
+    const render = (isFinal: boolean) => renderToStaticMarkup(createElement(ToolRenderer, {
+      toolName: 'bash', toolInput: { command: 'pwd' }, mode: 'input', density: 'detailed',
+      toolResult: { content, isError: false, isFinal, toolUseResult: { terminalId: 'terminal-1' } },
+    }));
+    assert.match(render(false), />Running</);
+    assert.doesNotMatch(render(true), />Running</);
+  }
+});

--- a/src/components/chat/tools/ToolRenderer.tsx
+++ b/src/components/chat/tools/ToolRenderer.tsx
@@ -22,7 +22,7 @@ function decodeToolData(value: unknown): unknown {
 }
 
 function statusFor(result: any): ToolStatus {
-  if (!result) return 'running';
+  if (!result || result.isFinal === false) return 'running';
   if (!result.isError) return 'completed';
   const message = String(result.content || '').toLowerCase().trim();
   return deniedPhrases.some((phrase) => message.includes(phrase)) ? 'denied' : 'error';
@@ -125,7 +125,7 @@ export const ToolRenderer: React.FC<ToolRendererProps> = ({ toolName, toolInput,
   const helpers = { selectedProject, createDiff, onFileOpen, toolResult };
   const contentProps = displayConfig.getContentProps?.(parsedData, helpers) || {};
   if (displayConfig.type === 'plan') {
-    return <PlanDisplay title={titleFrom(displayConfig, parsedData, 'Plan', helpers)} content={contentProps.content || ''} defaultOpen={collapsibleStartsOpen(rules, displayConfig.defaultOpen ?? false)} isStreaming={mode === 'input' && !toolResult} showRawParameters={mode === 'input' && showRawParameters} rawContent={rawToolInput} toolName={toolName} toolId={toolId} />;
+    return <PlanDisplay title={titleFrom(displayConfig, parsedData, 'Plan', helpers)} content={contentProps.content || ''} defaultOpen={collapsibleStartsOpen(rules, displayConfig.defaultOpen ?? false)} isStreaming={toolStatus === 'running'} showRawParameters={mode === 'input' && showRawParameters} rawContent={rawToolInput} toolName={toolName} toolId={toolId} />;
   }
   if (displayConfig.type !== 'collapsible') return null;
 

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -12,7 +12,7 @@ export type Provider = LLMProvider;
 export type PermissionMode = 'default' | 'acceptEdits' | 'auto' | 'bypassPermissions' | 'plan';
 
 export interface ChatImage { data?: string; mimeType?: string; name?: string; path?: string; }
-export interface ToolResult { content?: unknown; isError?: boolean; timestamp?: string | number | Date; toolUseResult?: unknown; [key: string]: unknown; }
+export interface ToolResult { content?: unknown; isError?: boolean; isFinal?: boolean; timestamp?: string | number | Date; toolUseResult?: unknown; [key: string]: unknown; }
 export interface SubagentChildTool { timestamp: Date; toolId: string; toolInput: unknown; toolName: string; toolResult?: ToolResult | null; }
 interface SubagentState { childTools: SubagentChildTool[]; currentToolIndex: number; isComplete: boolean; }
 

--- a/src/components/chat/utils/toolActivity.ts
+++ b/src/components/chat/utils/toolActivity.ts
@@ -116,13 +116,14 @@ export function currentTurnMessages(messages: ChatMessage[]): ChatMessage[] {
 }
 
 /**
- * A call is in flight until its result lands. A subagent container is in
+ * A call is in flight until its final result lands. A subagent container is in
  * flight until the task reports completion, whatever its child tools did.
  */
 export const isToolCallRunning = (message: ChatMessage): boolean => {
   if (!message.isToolUse) return false;
-  if (message.isSubagentContainer) return !message.toolResult && !message.subagentState?.isComplete;
-  return !message.toolResult;
+  const pending = !message.toolResult || message.toolResult.isFinal === false;
+  if (message.isSubagentContainer) return pending && !message.subagentState?.isComplete;
+  return pending;
 };
 
 export function runningToolCalls(messages: ChatMessage[]): ChatMessage[] {

--- a/src/components/chat/view/ChatComposer.dom.bun.test.tsx
+++ b/src/components/chat/view/ChatComposer.dom.bun.test.tsx
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { cleanup, render, within } from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { createElement, type ComponentProps } from 'react';
+import type { DropzoneInputProps, DropzoneRootProps } from 'react-dropzone';
+import { I18nextProvider } from 'react-i18next';
+
+import { defaultProjectPermissions } from '../../../hooks/useProjectPermissions';
+import english from '../../../i18n/locales/en/chat.json';
+import korean from '../../../i18n/locales/ko/chat.json';
+
+import ChatComposer from './ChatComposer';
+
+type ComposerProps = ComponentProps<typeof ChatComposer>;
+
+const i18n = createInstance();
+await i18n.init({ lng: 'en', resources: { en: { chat: english }, ko: { chat: korean } } });
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+function composerProps(overrides: Partial<ComposerProps> = {}): ComposerProps {
+  return {
+    pendingPermissionRequests: [],
+    handlePermissionDecision() {},
+    isLoading: false,
+    onAbortSession() {},
+    sessionState: null,
+    onShowTokenUsage() {},
+    onSubmit() {},
+    onSteer() {},
+    isDragActive: false,
+    queuedDrafts: [],
+    onEditQueuedDraft() {},
+    onDeleteQueuedDraft() {},
+    onMoveQueuedDraft() {},
+    pendingCommandGate: null,
+    onConfirmCommandGate() {},
+    onCancelCommandGate() {},
+    attachedImages: [],
+    onRemoveImage() {},
+    uploadingImages: new Map(),
+    imageErrors: new Map(),
+    showFileDropdown: false,
+    filteredFiles: [],
+    selectedFileIndex: 0,
+    onSelectFile() {},
+    filteredCommands: [],
+    skillCommands: [{ name: '/skill:review', type: 'skill' }],
+    selectedCommandIndex: 0,
+    onCommandSelect() {},
+    onCloseCommandMenu() {},
+    isCommandMenuOpen: false,
+    frequentCommands: [],
+    getRootProps: <T extends DropzoneRootProps>(props?: T) => props ?? ({} as T),
+    getInputProps: <T extends DropzoneInputProps>(props?: T) => props ?? ({} as T),
+    openImagePicker() {},
+    inputHighlightRef: { current: null },
+    renderInputWithMentions: (text) => text,
+    textareaRef: { current: null },
+    input: '',
+    onInputChange() {},
+    onTextareaClick() {},
+    onTextareaKeyDown() {},
+    onTextareaPaste() {},
+    onTextareaScrollSync() {},
+    onTextareaInput() {},
+    placeholder: 'Message Gajae Code',
+    isTextareaExpanded: false,
+    sendByCtrlEnter: true,
+    modelPreset: 'openai-codex/gpt-6-astra',
+    modelPresetOptions: [{ value: 'current', label: 'Current' }],
+    modelOptions: [{ value: 'openai-codex/gpt-6-astra', label: 'Astra' }],
+    reasoningEffort: 'xhigh',
+    permissions: defaultProjectPermissions('project-one'),
+    ...overrides,
+  };
+}
+
+function composer(props: ComposerProps) {
+  return createElement(I18nextProvider, { i18n }, createElement(ChatComposer, props));
+}
+
+function slot(container: HTMLElement, name: string) {
+  const element = container.querySelector<HTMLElement>(`[data-slot="prompt-input${name ? `-${name}` : ''}"]`);
+  assert.ok(element, `missing prompt input ${name || 'form'}`);
+  return element;
+}
+
+// happy-dom does not calculate flex geometry. These assertions protect the
+// layout structure and sizing rules; native WebKit QA measures the real bounds.
+for (const language of ['en', 'ko']) {
+  test(`the long ${language} Ctrl+Enter hint stays outside toolbar sizing while typing and clearing`, async () => {
+    await i18n.changeLanguage(language);
+    const props = composerProps();
+    const view = render(composer(props));
+    const form = slot(view.container, '');
+    const footer = slot(form, 'footer');
+    const tools = slot(footer, 'tools');
+    const hint = within(form).getByText(i18n.t('input.hintText.ctrlEnter', { ns: 'chat' }));
+    const send = within(footer).getByRole('button', { name: i18n.t('input.send', { ns: 'chat' }) });
+    const actions = send.parentElement!;
+    const toolsMarkup = tools.outerHTML;
+    const actionClasses = actions.className;
+    const hintClasses = hint.className.replace(/opacity-(0|100)/, '');
+
+    assert.ok((hint.textContent?.length ?? 0) > 50, 'exercise the full translated shortcut help');
+    assert.equal(hint.parentElement?.getAttribute('data-slot'), 'prompt-input', 'hint must occupy its own form row');
+    assert.equal(footer.nextElementSibling === hint, true, 'hint must follow, not compete with, the toolbar');
+    assert.equal(footer.children.length, 2, 'toolbar contains only tools and actions');
+    assert.equal(actions.contains(hint), false);
+    assert.ok(hint.classList.contains('wrap-anywhere'), 'long localized text must wrap within its row');
+    assert.ok(footer.classList.contains('flex-wrap'), 'a narrow pane can wrap the action group');
+    assert.ok(footer.classList.contains('items-end'), 'Send/Stop stays at the bottom of wrapped tools');
+    assert.ok(tools.classList.contains('flex-wrap'), 'narrow panes must keep trailing tools reachable');
+    assert.equal(tools.classList.contains('overflow-hidden'), false);
+
+    for (const input of ['Draft message', '   ', 'Another draft', '']) {
+      view.rerender(composer({ ...props, input }));
+      const currentHint = within(form).getByText(i18n.t('input.hintText.ctrlEnter', { ns: 'chat' }));
+      assert.equal(currentHint === hint, true, 'typing must keep the hint row mounted');
+      assert.equal(hint.className.replace(/opacity-(0|100)/, ''), hintClasses, 'typing only changes hint opacity');
+      assert.ok(hint.classList.contains(input.trim() ? 'opacity-0' : 'opacity-100'));
+      assert.equal(hint.hidden, false);
+      assert.equal(hint.style.display, '');
+      assert.equal(slot(footer, 'tools') === tools, true);
+      assert.equal(tools.outerHTML, toolsMarkup, 'typing does not change tool slots or widths');
+      assert.equal(send.parentElement === actions, true);
+      assert.equal(actions.className, actionClasses);
+      assert.equal(send.hasAttribute('disabled'), !input.trim());
+    }
+  });
+}
+
+test('model and permission slots retain their widths as metadata loads beside a hidden hint', async () => {
+  await i18n.changeLanguage('en');
+  const props = composerProps({ input: 'Draft message' });
+  const view = render(composer({
+    ...props, modelOptions: [], modelPresetOptions: [], modelPresetsLoading: true, permissions: null,
+  }));
+  const tools = slot(view.container, 'tools');
+  const model = within(tools).getByRole('button', { name: 'Model and reasoning settings' });
+  const modelSlot = model.parentElement!;
+  const permissionSlot = tools.children[3];
+  const skills = within(tools).getByRole('button', { name: english.input.skills.label });
+
+  assert.ok(modelSlot.classList.contains('w-40'));
+  assert.ok(modelSlot.classList.contains('sm:w-56'));
+  assert.ok(modelSlot.classList.contains('max-w-full'), 'model slot must fit a narrow tools row');
+  assert.ok(modelSlot.classList.contains('shrink-0'));
+  assert.ok(permissionSlot.classList.contains('w-28'));
+  assert.ok(permissionSlot.classList.contains('shrink-0'));
+  assert.equal(permissionSlot.getAttribute('aria-hidden'), 'true');
+  assert.equal(model.hasAttribute('disabled'), true);
+
+  view.rerender(composer({ ...props, modelPresetsLoading: false }));
+  assert.equal(within(tools).getByRole('button', { name: 'Model and reasoning settings' }) === model, true);
+  assert.equal(model.parentElement === modelSlot, true);
+  assert.equal(model.hasAttribute('disabled'), false);
+  const permissions = within(tools).getByRole('button', { name: 'Permission mode' }).parentElement!;
+  assert.equal(tools.children[3] === permissions, true);
+  assert.ok(permissions.classList.contains('w-28'));
+  assert.ok(permissions.classList.contains('shrink-0'));
+  assert.equal(within(tools).getByRole('button', { name: english.input.skills.label }) === skills, true);
+});
+
+for (const sendByCtrlEnter of [false, true]) {
+  test(`Send, Stop, Queue and Steer retain their native button roles with Ctrl+Enter ${sendByCtrlEnter}`, async () => {
+    await i18n.changeLanguage('en');
+    const props = composerProps({ sendByCtrlEnter });
+    const view = render(composer(props));
+    const form = slot(view.container, '');
+    const footer = slot(form, 'footer');
+
+    for (const state of [
+      { isLoading: false, input: '', labels: [english.input.send] },
+      { isLoading: false, input: 'Draft message', labels: [english.input.send] },
+      { isLoading: true, input: '', labels: [`${english.input.stop} · Esc`] },
+      { isLoading: true, input: 'Draft message', labels: [english.input.queue.steerNow, english.input.queue.sendNext, `${english.input.stop} · Esc`] },
+      { isLoading: true, input: '/help', labels: [english.input.queue.sendNext, `${english.input.stop} · Esc`] },
+    ]) {
+      view.rerender(composer({ ...props, isLoading: state.isLoading, input: state.input }));
+      const actions = footer.lastElementChild as HTMLElement;
+      const buttons = within(actions).getAllByRole('button');
+      assert.deepEqual(buttons.map((button) => button.getAttribute('aria-label')), state.labels);
+      assert.deepEqual(buttons.map((button) => button.getAttribute('type')), state.labels.map(() => state.isLoading ? 'button' : 'submit'));
+      assert.equal(buttons.some((button) => button.hasAttribute('disabled')), !state.isLoading && !state.input);
+
+      if (sendByCtrlEnter || (state.isLoading && state.input)) {
+        const hintText = state.isLoading && state.input ? english.input.hintText.queue : english.input.hintText.ctrlEnter;
+        const hint = within(form).getByText(hintText);
+        assert.equal(hint.parentElement?.getAttribute('data-slot'), 'prompt-input', 'queue help must not consume action width either');
+        assert.equal(footer.nextElementSibling === hint, true);
+      } else {
+        assert.equal(footer.nextElementSibling, null, 'default Enter mode keeps its existing idle appearance');
+      }
+    }
+  });
+}

--- a/src/components/chat/view/ChatComposer.tsx
+++ b/src/components/chat/view/ChatComposer.tsx
@@ -431,7 +431,7 @@ export default function ChatComposer({
             />
         </PromptInputBody>
 
-        <PromptInputFooter className="flex-wrap gap-y-1">
+        <PromptInputFooter className="flex-wrap items-end gap-y-1">
           {/*
             Wraps rather than clips. This row carries attach, voice, two model
             controls, skills and context usage; `overflow-hidden` meant a narrow
@@ -496,15 +496,6 @@ export default function ChatComposer({
           </PromptInputTools>
 
           <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
-            {(canQueueDraft || sendByCtrlEnter) && (
-              <div
-                className={`hidden text-xs text-muted-foreground/50 transition-opacity duration-200 lg:block ${
-                  input.trim() && !canQueueDraft ? 'opacity-0' : 'opacity-100'
-                }`}
-              >
-                {submitHint}
-              </div>
-            )}
             {canSteer && (
               <PromptInputButton
                 onClick={onSteer}
@@ -571,6 +562,18 @@ export default function ChatComposer({
             )}
           </div>
         </PromptInputFooter>
+        {/* Opacity keeps the hint's space while typing. Give it its own row so
+            even invisible translated text cannot squeeze the toolbar. */}
+        {(canQueueDraft || sendByCtrlEnter) && (
+          <div
+            data-slot="prompt-input-submit-hint"
+            className={`hidden min-w-0 px-3 pb-2 text-right text-xs wrap-anywhere text-muted-foreground/50 transition-opacity duration-200 lg:block ${
+              input.trim() && !canQueueDraft ? 'opacity-0' : 'opacity-100'
+            }`}
+          >
+            {submitHint}
+          </div>
+        )}
       </PromptInput>
       </div>}
     </div>

--- a/src/components/chat/view/ModelAndReasoningPicker.dom.bun.test.tsx
+++ b/src/components/chat/view/ModelAndReasoningPicker.dom.bun.test.tsx
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { createElement } from 'react';
+import { cleanup, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import '../../../i18n/config';
+import { useEscapeToAbort } from '../hooks/useEscapeToAbort';
+
+import ModelAndReasoningPicker from './ModelAndReasoningPicker';
+import type { ReasoningEffort } from './reasoningEffort';
+
+afterEach(cleanup);
+
+const searchName = 'Search providers and models';
+
+async function openPicker() {
+  const selectedModels: string[] = [];
+  const selectedEfforts: ReasoningEffort[] = [];
+  const view = render(createElement(ModelAndReasoningPicker, {
+    value: 'openai-codex/astra',
+    presetOptions: [],
+    modelOptions: [{
+      value: 'openai-codex/astra',
+      label: 'Astra',
+      effort: { values: [{ value: 'xhigh' }] },
+    }],
+    onSelect: (modelId) => { selectedModels.push(modelId); },
+    reasoningEffort: 'xhigh',
+    onSelectReasoningEffort: (effort) => { selectedEfforts.push(effort); },
+  }));
+  const trigger = screen.getByRole('button', { name: 'Model and reasoning settings' });
+  fireEvent.click(trigger);
+  const search = screen.getByRole<HTMLInputElement>('textbox', { name: searchName });
+  await waitFor(() => assert.equal(document.activeElement === search, true));
+  return { ...view, trigger, search, selectedModels, selectedEfforts };
+}
+
+function assertDismissed(trigger: HTMLElement) {
+  assert.equal(trigger.getAttribute('aria-expanded'), 'false');
+  assert.equal(screen.queryByRole('textbox', { name: searchName }) === null, true);
+  assert.equal(document.activeElement === trigger, true);
+}
+
+function AbortProbe({ canAbort, onAbort }: { canAbort: boolean; onAbort: () => void }) {
+  useEscapeToAbort(canAbort, onAbort);
+  return null;
+}
+
+test('Escape from an empty search dismisses the portal, restores trigger focus, and allows reopening', async () => {
+  const { trigger, search, selectedModels, selectedEfforts } = await openPicker();
+
+  fireEvent.keyDown(search, { key: 'Escape' });
+
+  assertDismissed(trigger);
+  assert.deepEqual(selectedModels, []);
+  assert.deepEqual(selectedEfforts, []);
+
+  const closedEscape = createEvent.keyDown(trigger, { key: 'Escape' });
+  fireEvent(trigger, closedEscape);
+  assert.equal(closedEscape.defaultPrevented, false, 'the closed picker releases Escape');
+
+  fireEvent.click(trigger);
+  const reopenedSearch = screen.getByRole('textbox', { name: searchName });
+  await waitFor(() => assert.equal(document.activeElement === reopenedSearch, true));
+  fireEvent.keyDown(reopenedSearch, { key: 'Escape' });
+  assertDismissed(trigger);
+});
+
+for (const query of ['astra', 'no-such-model']) {
+  test(`Escape first clears the search "${query}" without dismissing, then dismisses on the next press`, async () => {
+    const { trigger, search } = await openPicker();
+    fireEvent.change(search, { target: { value: query } });
+    assert.equal(search.value, query);
+
+    fireEvent.keyDown(search, { key: 'Escape' });
+
+    assert.equal(search.value, '');
+    assert.equal(trigger.getAttribute('aria-expanded'), 'true');
+    assert.equal(document.activeElement === search, true);
+    assert.equal(screen.queryByRole('option', { name: 'Astra' }) !== null, true);
+
+    fireEvent.keyDown(search, { key: 'Escape' });
+    assertDismissed(trigger);
+  });
+}
+
+for (const optionName of ['ChatGPT', 'Astra', 'Extra high']) {
+  test(`Escape from the focused "${optionName}" option dismisses and restores trigger focus`, async () => {
+    const { trigger, selectedModels, selectedEfforts } = await openPicker();
+    const option = screen.getByRole('option', { name: optionName });
+    option.focus();
+    assert.equal(document.activeElement === option, true);
+
+    fireEvent.keyDown(option, { key: 'Escape' });
+
+    assertDismissed(trigger);
+    assert.deepEqual(selectedModels, []);
+    assert.deepEqual(selectedEfforts, []);
+  });
+}
+
+test('Escape outside the search restores trigger focus even when the filter has no matches', async () => {
+  const { trigger, search } = await openPicker();
+  fireEvent.change(search, { target: { value: 'no-such-model' } });
+  assert.equal(trigger.hasAttribute('disabled'), true);
+  const defaultOption = screen.getByRole('button', { name: /Keep current configuration/ });
+  defaultOption.focus();
+  assert.equal(document.activeElement === defaultOption, true);
+
+  fireEvent.keyDown(defaultOption, { key: 'Escape' });
+
+  assert.equal(trigger.hasAttribute('disabled'), false);
+  assertDismissed(trigger);
+});
+
+for (const query of ['', 'astra']) {
+  test(`an already-prevented Escape leaves the picker and search "${query}" alone`, async () => {
+    const { trigger, search } = await openPicker();
+    fireEvent.change(search, { target: { value: query } });
+    const escape = createEvent.keyDown(search, { key: 'Escape' });
+    escape.preventDefault();
+
+    fireEvent(search, escape);
+
+    assert.equal(trigger.getAttribute('aria-expanded'), 'true');
+    assert.equal(search.value, query);
+    assert.equal(document.activeElement === search, true);
+  });
+
+  test(`global Stop owns Escape with search "${query}" until the run is no longer stoppable`, async () => {
+    const { trigger, search } = await openPicker();
+    fireEvent.change(search, { target: { value: query } });
+    let aborts = 0;
+    const onAbort = () => { aborts++; };
+    // Register the real capture listener after the popup's bubble listener.
+    const abortView = render(createElement(AbortProbe, { canAbort: true, onAbort }));
+    const escape = createEvent.keyDown(search, { key: 'Escape' });
+
+    fireEvent(search, escape);
+
+    assert.equal(aborts, 1);
+    assert.equal(escape.defaultPrevented, true);
+    assert.equal(trigger.getAttribute('aria-expanded'), 'true');
+    assert.equal(search.value, query);
+    assert.equal(document.activeElement === search, true);
+
+    abortView.rerender(createElement(AbortProbe, { canAbort: false, onAbort }));
+    if (query) {
+      fireEvent.keyDown(search, { key: 'Escape' });
+      assert.equal(search.value, '');
+      assert.equal(trigger.getAttribute('aria-expanded'), 'true');
+      assert.equal(document.activeElement === search, true);
+    }
+    fireEvent.keyDown(search, { key: 'Escape' });
+    assertDismissed(trigger);
+    assert.equal(aborts, 1);
+  });
+}
+
+test('other keys leave the popup open and outside clicks dismiss without stealing focus', async () => {
+  const { trigger, search } = await openPicker();
+  fireEvent.keyDown(search, { key: 'ArrowDown' });
+  assert.equal(trigger.getAttribute('aria-expanded'), 'true');
+
+  render(createElement('button', null, 'Outside'));
+  const outside = screen.getByRole('button', { name: 'Outside' });
+  outside.focus();
+  fireEvent.mouseDown(outside);
+
+  assert.equal(trigger.getAttribute('aria-expanded'), 'false');
+  assert.equal(screen.queryByRole('textbox', { name: searchName }) === null, true);
+  assert.equal(document.activeElement === outside, true);
+});

--- a/src/components/chat/view/ModelAndReasoningPicker.tsx
+++ b/src/components/chat/view/ModelAndReasoningPicker.tsx
@@ -230,7 +230,9 @@ export default function ModelAndReasoningPicker({
   /** Model whose reasoning levels the third column offers. */
   const [activeModel, setActiveModel] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
+  const returnFocus = useRef(false);
   const [popupPosition, setPopupPosition] = useState({ bottom: 0, left: 0 });
   const [query, setQuery] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
@@ -274,8 +276,20 @@ export default function ModelAndReasoningPicker({
       const target = event.target as Node;
       if (!rootRef.current?.contains(target) && !popupRef.current?.contains(target)) setOpen(false);
     };
+    const closeForEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      event.preventDefault();
+      returnFocus.current = true;
+      // Clear the filter before restoring focus: no matches disables the trigger.
+      setQuery('');
+      setOpen(false);
+    };
     document.addEventListener('mousedown', close);
-    return () => document.removeEventListener('mousedown', close);
+    document.addEventListener('keydown', closeForEscape);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', closeForEscape);
+    };
   }, [open]);
 
   useEffect(() => {
@@ -283,6 +297,8 @@ export default function ModelAndReasoningPicker({
       setActiveProvider(null);
       setActiveModel(null);
       setQuery('');
+      if (returnFocus.current) triggerRef.current?.focus();
+      returnFocus.current = false;
       return;
     }
     window.requestAnimationFrame(() => searchRef.current?.focus());
@@ -326,6 +342,7 @@ export default function ModelAndReasoningPicker({
   return (
     <div ref={rootRef} className="relative w-40 max-w-full shrink-0 sm:w-56">
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen((current) => !current)}
         disabled={loading || selecting || groups.length === 0}
@@ -375,7 +392,12 @@ export default function ModelAndReasoningPicker({
               ref={searchRef}
               value={query}
               onChange={(event) => { setQuery(event.target.value); setActiveProvider(null); }}
-              onKeyDown={(event) => { if (event.key === 'Escape' && query) { event.stopPropagation(); setQuery(''); } }}
+              onKeyDown={(event) => {
+                if (event.key !== 'Escape' || event.defaultPrevented || !query) return;
+                event.preventDefault();
+                event.stopPropagation();
+                setQuery('');
+              }}
               placeholder={t('input.modelReasoning.search')}
               aria-label={t('input.modelReasoning.search')}
               className="h-7 w-full rounded-md border border-input bg-background pr-2 pl-7 text-xs outline-hidden placeholder:text-muted-foreground focus:border-ring"

--- a/src/stores/useSessionStore.dom.bun.test.tsx
+++ b/src/stores/useSessionStore.dom.bun.test.tsx
@@ -6,8 +6,10 @@ import { act, cleanup, render } from '@testing-library/react';
 import { createElement } from 'react';
 
 import { useLastTurnChanges, type LastTurnFile } from '../components/workspace/hooks/useLastTurnChanges';
+import { normalizedToChatMessages } from '../components/chat/hooks/useChatMessages';
+import { isToolCallRunning } from '../components/chat/utils/toolActivity';
 
-import { useSessionStore, type SessionSlot, type SessionStore } from './useSessionStore';
+import { useSessionStore, type NormalizedMessage, type SessionSlot, type SessionStore } from './useSessionStore';
 
 type PendingRequest = {
   url: string;
@@ -37,6 +39,64 @@ function createStore(): SessionStore {
 }
 
 afterEach(cleanup);
+
+for (const delivery of ['live', 'replay'] as const) {
+  test(`${delivery} metadata-only tool updates retain output and merge partial details until final completion`, () => {
+    const store = createStore();
+    const base = { sessionId: 'session', timestamp: '2026-09-06T00:00:00Z', provider: 'gjc' as const, toolId: 'tool-1' };
+    const frames: NormalizedMessage[] = [
+      { ...base, id: 'call', kind: 'tool_use', toolName: 'bash', toolInput: { command: 'pwd' } },
+      { ...base, id: 'output', kind: 'tool_result', content: 'Already streamed output', isError: false, isFinal: false,
+        toolUseResult: { async: { jobId: 'job-1', type: 'bash' }, files: ['old'] } },
+      { ...base, id: 'metadata', kind: 'tool_result', content: '', isError: false, isFinal: false,
+        toolUseResult: { terminalId: 'terminal-1', async: { state: 'running' }, files: ['new'] } },
+    ];
+    act(() => {
+      if (delivery === 'replay') store.appendRealtimeBatch('session', frames);
+      else frames.forEach((frame) => store.appendRealtime('session', frame));
+    });
+    const [running] = normalizedToChatMessages(store.getMessages('session'));
+    assert.equal(running.toolResult?.content, 'Already streamed output');
+    assert.equal(running.toolResult?.isFinal, false);
+    assert.equal(isToolCallRunning(running), true);
+    assert.deepEqual(running.toolResult?.toolUseResult, {
+      terminalId: 'terminal-1', async: { jobId: 'job-1', type: 'bash', state: 'running' }, files: ['new'],
+    });
+    assert.deepEqual(frames[1].toolUseResult, { async: { jobId: 'job-1', type: 'bash' }, files: ['old'] }, 'earlier frames stay immutable');
+    assert.equal(normalizedToChatMessages(store.getMessages('session'))[0], running, 'unchanged merged rows retain render identity');
+
+    act(() => store.appendRealtime('session', { ...base, id: 'more-output', kind: 'tool_result', content: 'New output', isError: false, isFinal: false }));
+    const updated = normalizedToChatMessages(store.getMessages('session'))[0];
+    assert.equal(updated.toolResult?.content, 'New output', 'nonempty partial output replaces the cumulative display');
+    assert.deepEqual(updated.toolResult?.toolUseResult, running.toolResult?.toolUseResult, 'omitted details preserve the previous result');
+
+    act(() => store.appendRealtime('session', { ...base, id: 'final', kind: 'tool_result', content: '', isError: false, isFinal: true, toolUseResult: { exitCode: 0 } }));
+    const finished = normalizedToChatMessages(store.getMessages('session'))[0];
+    assert.equal(finished.toolResult?.content, '', 'an authoritative final result can deliberately clear output');
+    assert.deepEqual(finished.toolResult?.toolUseResult, { exitCode: 0 }, 'final details replace partial metadata');
+    assert.equal(isToolCallRunning(finished), false);
+
+    act(() => store.appendRealtime('session', { ...base, id: 'late-metadata', kind: 'tool_result', content: '', isError: false, isFinal: false, toolUseResult: { async: { state: 'completed' } } }));
+    const late = normalizedToChatMessages(store.getMessages('session'))[0];
+    assert.equal(late.toolResult?.isFinal, true, 'late metadata does not reopen a finished invocation');
+    assert.deepEqual(late.toolResult?.toolUseResult, { exitCode: 0, async: { state: 'completed' } });
+  });
+}
+
+test('replacing a realtime tool result ID retains its earlier output and details', () => {
+  const store = createStore();
+  const base = { sessionId: 'session', timestamp: '2026-09-06T00:00:00Z', provider: 'gjc' as const, toolId: 'tool-1' };
+  act(() => store.appendRealtimeBatch('session', [
+    { ...base, id: 'call', kind: 'tool_use', toolName: 'read', toolInput: { path: 'a.ts' } },
+    { ...base, id: 'result', kind: 'tool_result', content: 'file text', isError: false, isFinal: false, toolUseResult: { resolvedPath: '/repo/a.ts' } },
+    { ...base, id: 'result', kind: 'tool_result', content: '', isError: false, isFinal: false, toolUseResult: { truncated: true } },
+  ]));
+  const messages = store.getMessages('session');
+  assert.equal(messages.length, 2);
+  const result = normalizedToChatMessages(messages)[0].toolResult;
+  assert.equal(result?.content, 'file text');
+  assert.deepEqual(result?.toolUseResult, { resolvedPath: '/repo/a.ts', truncated: true });
+});
 
 test('a shared session store exposes completed mutations to the Last turn hook', () => {
   let store: SessionStore | undefined;

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -12,7 +12,7 @@ export interface NormalizedMessage {
   id: string; sessionId: string; timestamp: string; provider: LLMProvider; kind: MessageKind; seq?: number; replayGeneration?: string;
   role?: 'user' | 'assistant'; content?: string; displayText?: string; commandName?: string; commandMessage?: string; commandArgs?: string;
   isLocalCommand?: boolean; isLocalCommandStdout?: boolean; isCompactSummary?: boolean; images?: Array<{ path?: string; data?: string; name?: string }>;
-  toolName?: string; toolInput?: unknown; toolId?: string; toolResult?: { content: string; isError: boolean; toolUseResult?: unknown } | null;
+  toolName?: string; toolInput?: unknown; toolId?: string; toolResult?: { content: string; isError: boolean; isFinal?: boolean; toolUseResult?: unknown } | null; toolUseResult?: unknown;
   toolResultTruncated?: boolean; toolResultBytes?: number; isError?: boolean; level?: 'info' | 'warning' | 'error'; text?: string; tokens?: number;
   canInterrupt?: boolean; tokenBudget?: unknown; requestId?: string; input?: unknown; context?: unknown; newSessionId?: string; status?: string;
   summary?: string; exitCode?: number; actualSessionId?: string; parentToolUseId?: string; subagentTools?: unknown[]; isFinal?: boolean; sequence?: number; rowid?: number;
@@ -45,6 +45,32 @@ const messageTime = (message: NormalizedMessage) => {
 };
 const chronological = (left: NormalizedMessage, right: NormalizedMessage) => (messageTime(left) ?? 0) - (messageTime(right) ?? 0);
 const userContent = (message: NormalizedMessage) => message.kind === 'text' && message.role === 'user' && message.content?.trim() ? message.content.trim() : null;
+
+type ToolResultUpdate = Pick<NormalizedMessage, 'content' | 'isError' | 'isFinal' | 'toolUseResult'>;
+
+/** Partial details patch records; arrays and explicit null remain replacements. */
+function mergeToolDetails(previous: unknown, update: unknown): unknown {
+  if (update === undefined) return previous;
+  const record = (value: unknown): value is Record<string, unknown> => value !== null && typeof value === 'object' && !Array.isArray(value);
+  if (!record(previous) || !record(update)) return update;
+  return Object.fromEntries([
+    ...Object.entries(previous),
+    ...Object.entries(update).map(([key, value]) => [key, mergeToolDetails(Object.prototype.hasOwnProperty.call(previous, key) ? previous[key] : undefined, value)]),
+  ]);
+}
+
+function mergeToolUpdate(previous: ToolResultUpdate | undefined, update: NormalizedMessage): NormalizedMessage {
+  // Missing isFinal is the legacy final-result contract. Only explicit partial
+  // frames are patches; a final result can clear text and replace all details.
+  if (!previous || update.isFinal !== false) return update;
+  return {
+    ...update,
+    content: update.content || previous.content || '',
+    toolUseResult: mergeToolDetails(previous.toolUseResult, update.toolUseResult),
+    isError: previous.isError === true || update.isError === true,
+    isFinal: previous.isFinal !== false,
+  };
+}
 
 function withoutRepeatedIds(messages: NormalizedMessage[]) {
   const retained = new Set<string>();
@@ -328,7 +354,36 @@ export function useSessionStore() {
     } finally { slot._pendingRequests -= 1; if (slot._fetchMoreTicket === ticket) slot._fetchMoreTicket = null; if (slot._loadingTicket === ticket) slot._loadingTicket = null; evict(); }
   }, [emitSession, evict, queryClient, remember]);
 
-  const append = useCallback((id: string, messages: NormalizedMessage[]) => { if (!messages.length) return; const slot = getSlot(id); const index = new Map<string, number>(); const next = [...slot.realtimeMessages]; next.forEach((row, position) => { const key = messageKey(row); if (key) index.set(key, position); }); messages.forEach((row) => { const normalized = row.sessionId === id ? row : { ...row, sessionId: id }; const key = messageKey(normalized); const position = key ? index.get(key) : undefined; if (position === undefined) { if (key) index.set(key, next.length); next.push(normalized); } else next[position] = normalized; }); slot.realtimeMessages = next.length > MAX_REALTIME_MESSAGES ? next.slice(-MAX_REALTIME_MESSAGES) : next; refreshMerged(slot); emitSession(id); }, [emitSession, getSlot]);
+  const append = useCallback((id: string, messages: NormalizedMessage[]) => {
+    if (!messages.length) return;
+    const slot = getSlot(id);
+    refreshMerged(slot);
+    const results = new Map<string, ToolResultUpdate>();
+    for (const row of slot.merged) {
+      if (!row.toolId) continue;
+      if (row.kind === 'tool_use' && row.toolResult) results.set(row.toolId, row.toolResult);
+      else if (row.kind === 'tool_result') results.set(row.toolId, row);
+    }
+    const index = new Map<string, number>();
+    const next = [...slot.realtimeMessages];
+    next.forEach((row, position) => { const key = messageKey(row); if (key) index.set(key, position); });
+    messages.forEach((row) => {
+      let normalized = row.sessionId === id ? row : { ...row, sessionId: id };
+      if (normalized.toolId && normalized.kind === 'tool_result') {
+        normalized = mergeToolUpdate(results.get(normalized.toolId), normalized);
+        results.set(normalized.toolId!, normalized);
+      } else if (normalized.toolId && normalized.kind === 'tool_use' && normalized.toolResult) {
+        results.set(normalized.toolId, normalized.toolResult);
+      }
+      const key = messageKey(normalized);
+      const position = key ? index.get(key) : undefined;
+      if (position === undefined) { if (key) index.set(key, next.length); next.push(normalized); }
+      else next[position] = normalized;
+    });
+    slot.realtimeMessages = next.length > MAX_REALTIME_MESSAGES ? next.slice(-MAX_REALTIME_MESSAGES) : next;
+    refreshMerged(slot);
+    emitSession(id);
+  }, [emitSession, getSlot]);
   const appendRealtime = useCallback((id: string, message: NormalizedMessage) => append(id, [message]), [append]);
   const appendRealtimeBatch = useCallback((id: string, messages: NormalizedMessage[]) => append(id, messages), [append]);
 

--- a/website/src/releases.js
+++ b/website/src/releases.js
@@ -9,10 +9,10 @@ export const GAJAE_CODE_URL = 'https://github.com/devswha/gajae-code';
 export const APPLE_GATEKEEPER_HELP_URL = 'https://support.apple.com/102445';
 
 export const RELEASE = {
-  version: '2.0.0-beta.8',
-  tag: 'v2.0.0-beta.8',
+  version: '2.0.0-beta.9',
+  tag: 'v2.0.0-beta.9',
   channel: 'beta',
-  publishedLabel: '2026-08-31',
+  publishedLabel: '2026-09-06',
 };
 
 function releaseDownloadBase(tag = RELEASE.tag) {


### PR DESCRIPTION
Desktop UI preferences were lost whenever the supervised server received a new loopback port. The desktop now records its first verified server port and reuses that origin across launches, while rotating authentication secrets and retaining PID/health checks. An occupied or invalid saved port enters recovery instead of adopting another server.

This also preserves streaming tool metadata, errors, text and running state across partial updates. The model picker dismisses on Escape without bypassing global Stop. Ctrl+Enter guidance occupies a separate row so long or invisible text cannot squeeze toolbar controls; typing preserves their positions. macOS acceptance gets explicit isolated server/WebKit profiles; QA windows use the public builder setter because the pinned runtime drops the UUID during configuration conversion. Profile locks and path validation prevent competing or invalid launches from modifying profile data.

Release preparation advances to beta.9 / desktop 0.2.3. Linux server archives gain exact-source builds and authenticated runtime/data-survival checks on Ubuntu 22.04 and 24.04. Desktop artifact checkouts are pinned to the reviewed commit. The local release verifier now checks the actual gajae-app-server package identity, sharing that constant with the builder and smoke harness.

Validation: full npm run verify and all 16 GJC/browser/clone/native E2Es passed on 828d986. All eight PR checks passed, including both Linux packaging lanes and both Ubuntu versions. Independent adversarial review verified the QA isolation fixes and accepted the persisted-origin guards. Real signed-app GUI checks confirmed settings/project persistence, same-origin profile separation, rejection of an occupied port with zero foreign requests, Retry recovery and complete child-process shutdown. The corrected toolbar remains horizontal while typing with Ctrl+Enter enabled. The exact-head beta.9 release is published with the macOS DMG, Linux deb/AppImage and server archive plus all four checksums. App and DMG notarization, mounted/quarantined-copy signatures and Gatekeeper, packaged-server/data-survival checks, installed-copy GUI and remote release-asset verification all passed before publication.

OMG skill execution is excluded from this acceptance scope. Historical issue #3 is not declared resolved by the app transport fixes. Hosted signing still requires owner-provided secrets; local release preparation uses the existing identity and notary profile without exporting credentials. No announcement is sent by the new archive workflow.
