### PR TITLE
fix(website): prioritize desktop downloads and clarify app identity

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,16 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Gajae Code App — Gajae Code, with a desktop</title>
+    <title>Gajae Code App — The desktop app for Gajae Code</title>
     <meta
       name="description"
-      content="A local desktop and web interface for Gajae Code. Open projects, resume sessions, and use the setup already on your machine."
+      content="The desktop app for Gajae Code. Open projects, resume sessions, and review changes—all in one local workspace. Available for macOS and Linux."
     />
     <meta name="theme-color" content="#101615" />
-    <meta property="og:title" content="Gajae Code App" />
+    <meta property="og:title" content="Gajae Code App — The desktop app for Gajae Code" />
     <meta
       property="og:description"
-      content="Gajae Code, with a desktop. Projects, sessions, presets, and skills on your machine."
+      content="Open projects, resume sessions, and review changes—all in one local workspace. Download the desktop app for macOS or Linux."
     />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://devswha.github.io/gajae-code-app/screenshots/session-review.jpg" />

--- a/website/src/page.js
+++ b/website/src/page.js
@@ -2,6 +2,7 @@ import {
   APPLE_GATEKEEPER_HELP_URL,
   DOWNLOADS,
   DOCS_INSTALL_URL,
+  DOCS_LINUX_INSTALL_URL,
   DOCS_SELF_HOST_URL,
   GAJAE_CODE_URL,
   ISSUES_URL,
@@ -14,14 +15,6 @@ import {
 
 function appleIcon() {
   return `<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16" aria-hidden="true"><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>`;
-}
-
-function codeIcon() {
-  return `<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16" aria-hidden="true"><path d="m8 9-3 3 3 3"/><path d="m16 9 3 3-3 3"/><path d="m14 5-4 14"/></svg>`;
-}
-
-function terminalIcon() {
-  return `<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16" aria-hidden="true"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>`;
 }
 
 function faqItem(question, answer) {
@@ -56,39 +49,38 @@ export function renderLandingPage() {
 
       <main>
         <section class="hero" id="top">
-          <h1>Gajae Code,<br />with a desktop.</h1>
+          <p class="eyebrow">Public beta · v${RELEASE.version}</p>
+          <h1>The desktop app<br />for Gajae Code.</h1>
           <p class="lede">
-            Open projects, resume sessions, and run Gajae Code from one local workspace.
-            The app uses the setup already on your machine.
+            Open projects, resume sessions, and review changes—all in one local workspace.
           </p>
           <div class="cta-row">
-            <a class="button button-primary" href="${DOWNLOADS.macosArm64.href}" aria-describedby="macos-beta-notice">
-              ${appleIcon()}
-              Download for Mac
-            </a>
-            <a class="button button-secondary" href="${REPOSITORY_URL}">
-              ${codeIcon()}
-              Source
-            </a>
-            <a class="button button-icon" href="${DOWNLOADS.linuxServer.href}" aria-label="Download Linux server archive">
-              ${terminalIcon()}
-            </a>
+            <div class="platform-cta">
+              <a class="button button-primary" href="${DOWNLOADS.macosArm64.href}" aria-describedby="macos-beta-notice">
+                ${appleIcon()}
+                Download for macOS
+              </a>
+              <p class="platform-note" id="macos-beta-notice">Apple Silicon · macOS 11+ · Notarized by Apple</p>
+            </div>
+            <div class="platform-cta">
+              <a class="button button-secondary" href="#linux-download" aria-describedby="linux-desktop-notice">Download for Linux</a>
+              <p class="platform-note" id="linux-desktop-notice">x86_64 · .deb / AppImage</p>
+            </div>
           </div>
-          <a class="quiet-link all-downloads" href="#download">All download options</a>
-          <p class="release-meta" id="macos-beta-notice">
-            <span>Public beta</span>
-            Apple Silicon · macOS 11+ · Notarized by Apple
-            <a href="#macos-install">First-launch instructions</a>
-          </p>
+          <div class="hero-links">
+            <a class="quiet-link" href="${GAJAE_CODE_URL}">About Gajae Code</a>
+            <a class="quiet-link" href="${REPOSITORY_URL}">Source code</a>
+            <a class="quiet-link" href="#self-host">Server setup</a>
+          </div>
         </section>
 
         <section class="product-overview" id="features" aria-label="Gajae Code App session and review">
+          <img src="./screenshots/session-review.jpg" alt="A two-turn Gajae Code App session that writes greet.py and adds a --shout flag, with the Changes tab open on the diff and a review comment waiting to be sent" width="2880" height="1800" fetchpriority="high" />
           <div class="product-overview-copy">
             <p class="eyebrow">Real session · v${RELEASE.version}</p>
             <h2>Watch the work happen, then review it.</h2>
             <p>Each turn's tool calls fold into one block. The Changes tab shows the working tree as a diff, and a comment on a line becomes the next message.</p>
           </div>
-          <img src="./screenshots/session-review.jpg" alt="A two-turn Gajae Code App session that writes greet.py and adds a --shout flag, with the Changes tab open on the diff and a review comment waiting to be sent" width="2880" height="1800" />
         </section>
 
         <section class="details" id="workflow" aria-label="Product details">
@@ -98,7 +90,7 @@ export function renderLandingPage() {
               <h2>Commands wait for you.</h2>
               <p>By default a shell command stops the turn on a card: allow it once, always for this project, or deny it. The turn resumes where it paused.</p>
             </div>
-            <img src="./screenshots/permission-card.jpg" alt="A Gajae Code App turn paused on a permission card for python3 hello.py, with Deny, Always deny, Always allow and Allow buttons" width="2880" height="1800" />
+            <img src="./screenshots/permission-card.jpg" alt="A Gajae Code App turn paused on a permission card for python3 hello.py, with Deny, Always deny, Always allow and Allow buttons" width="2880" height="1800" loading="lazy" />
           </article>
           <article class="detail">
             <div class="detail-copy">
@@ -106,35 +98,65 @@ export function renderLandingPage() {
               <h2>Match the model to the task.</h2>
               <p>Pick the provider, the model and the reasoning depth for the next turn without leaving the session. A model chosen for a session stays with it.</p>
             </div>
-            <img src="./screenshots/model-picker.jpg" alt="The model and reasoning picker open above a session, with ChatGPT selected, GPT-5.6 Terra chosen and the reasoning column beside it" width="2880" height="1800" />
+            <img src="./screenshots/model-picker.jpg" alt="The model and reasoning picker open above a session, with ChatGPT selected, GPT-5.6 Terra chosen and the reasoning column beside it" width="2880" height="1800" loading="lazy" />
           </article>
         </section>
 
         <section class="download-section" id="download">
           <div class="section-copy">
             <p class="eyebrow">v${RELEASE.version}</p>
-            <h2>Download</h2>
-            <p>Versioned files from GitHub Releases. Checksums are published beside every artifact.</p>
+            <h2>Download the desktop app</h2>
+            <p>Versioned files from GitHub Releases. Each download has its own SHA-256 checksum.</p>
           </div>
           <div class="download-list">
             <div class="download-row">
               <div>
                 <h3>macOS</h3>
                 <p>Apple Silicon · macOS 11+</p>
+                <a class="quiet-link" href="#macos-install">First-launch instructions</a>
               </div>
               <div class="download-actions">
                 <a class="text-button" href="${DOWNLOADS.macosArm64.href}">Download DMG</a>
-                <a class="quiet-link" href="${DOWNLOADS.macosArm64.checksumHref}">SHA-256</a>
+                <a class="quiet-link" href="${DOWNLOADS.macosArm64.checksumHref}" aria-label="SHA-256 for macOS DMG">SHA-256</a>
               </div>
             </div>
+            <div class="download-row" id="linux-download" tabindex="-1" role="region" aria-labelledby="linux-download-title">
+              <div>
+                <h3 id="linux-download-title">Linux desktop</h3>
+                <p>x86_64 · Ubuntu 22.04 / 24.04</p>
+                <p>Node.js and Bun included.</p>
+                <a class="quiet-link" href="${DOCS_LINUX_INSTALL_URL}">Linux installation guide</a>
+              </div>
+              <div class="download-formats">
+                <div class="download-actions">
+                  <a class="text-button" href="${DOWNLOADS.linuxDeb.href}">Download .deb</a>
+                  <a class="quiet-link" href="${DOWNLOADS.linuxDeb.checksumHref}" aria-label="SHA-256 for Linux .deb">SHA-256</a>
+                </div>
+                <div class="download-actions">
+                  <a class="text-button" href="${DOWNLOADS.linuxAppImage.href}">Download AppImage</a>
+                  <a class="quiet-link" href="${DOWNLOADS.linuxAppImage.checksumHref}" aria-label="SHA-256 for Linux AppImage">SHA-256</a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p class="availability">Intel Mac and Windows builds are not available yet.</p>
+        </section>
+
+        <section class="self-host-section" id="self-host">
+          <div class="section-copy">
+            <h2>Prefer the web interface?</h2>
+            <p>Run Gajae Code App in your browser with the server archive or from source. These are alternatives to the desktop app.</p>
+          </div>
+          <div class="download-list">
             <div class="download-row">
               <div>
                 <h3>Linux server</h3>
-                <p>x86_64 · glibc 2.35+ · Node.js 22</p>
+                <p>x86_64 · glibc 2.35+ · Requires Node.js 22.22.2+ (22.x)</p>
+                <a class="quiet-link" href="${DOCS_SELF_HOST_URL}">Server installation guide</a>
               </div>
               <div class="download-actions">
                 <a class="text-button" href="${DOWNLOADS.linuxServer.href}">Download archive</a>
-                <a class="quiet-link" href="${DOWNLOADS.linuxServer.checksumHref}">SHA-256</a>
+                <a class="quiet-link" href="${DOWNLOADS.linuxServer.checksumHref}" aria-label="SHA-256 for Linux server archive">SHA-256</a>
               </div>
             </div>
             <div class="download-row">
@@ -147,7 +169,6 @@ export function renderLandingPage() {
               </div>
             </div>
           </div>
-          <p class="availability">Intel Mac, Windows, and Linux desktop builds are not available yet.</p>
         </section>
 
         <section class="install-section" id="macos-install">

--- a/website/src/releases.js
+++ b/website/src/releases.js
@@ -5,6 +5,7 @@ export const ISSUES_URL = `${REPOSITORY_URL}/issues`;
 export const LICENSE_URL = `${REPOSITORY_URL}/blob/main/LICENSE`;
 export const DOCS_INSTALL_URL = `${REPOSITORY_URL}/blob/main/docs/INSTALL.md`;
 export const DOCS_SELF_HOST_URL = `${REPOSITORY_URL}/blob/main/docs/SELF-HOST.md`;
+export const DOCS_LINUX_INSTALL_URL = `${REPOSITORY_URL}/blob/main/docs/DESKTOP-LINUX.md#install-or-launch-a-local-build`;
 export const GAJAE_CODE_URL = 'https://github.com/devswha/gajae-code';
 export const APPLE_GATEKEEPER_HELP_URL = 'https://support.apple.com/102445';
 
@@ -23,6 +24,14 @@ export function desktopDmgName(version = RELEASE.version) {
   return `gajae-app-desktop-${version}-macos-arm64.dmg`;
 }
 
+export function desktopDebName(version = RELEASE.version) {
+  return `gajae-app-desktop-${version}-linux-x64.deb`;
+}
+
+export function desktopAppImageName(version = RELEASE.version) {
+  return `gajae-app-desktop-${version}-linux-x64.AppImage`;
+}
+
 export function serverArchiveName(version = RELEASE.version) {
   return `gajae-app-server-${version}-linux-x64-node22.tar.gz`;
 }
@@ -37,6 +46,8 @@ export function downloadUrl(fileName, tag = RELEASE.tag) {
 
 export function buildDownloads(release = RELEASE) {
   const dmg = desktopDmgName(release.version);
+  const deb = desktopDebName(release.version);
+  const appImage = desktopAppImageName(release.version);
   const server = serverArchiveName(release.version);
   return {
     tagUrl: `${RELEASES_URL}/tag/${release.tag}`,
@@ -46,6 +57,20 @@ export function buildDownloads(release = RELEASE) {
       checksumHref: downloadUrl(checksumName(dmg), release.tag),
       checksumFile: checksumName(dmg),
       verifyCommand: `shasum -a 256 -c ${checksumName(dmg)}`,
+    },
+    linuxDeb: {
+      label: deb,
+      href: downloadUrl(deb, release.tag),
+      checksumHref: downloadUrl(checksumName(deb), release.tag),
+      checksumFile: checksumName(deb),
+      verifyCommand: `sha256sum --check ${checksumName(deb)}`,
+    },
+    linuxAppImage: {
+      label: appImage,
+      href: downloadUrl(appImage, release.tag),
+      checksumHref: downloadUrl(checksumName(appImage), release.tag),
+      checksumFile: checksumName(appImage),
+      verifyCommand: `sha256sum --check ${checksumName(appImage)}`,
     },
     linuxServer: {
       label: server,

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -40,6 +40,17 @@ a {
   text-decoration: none;
 }
 
+a:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--foreground);
+  outline-offset: 4px;
+  border-radius: 0.25rem;
+}
+
+[id] {
+  scroll-margin-top: 2rem;
+}
+
 img {
   display: block;
   max-width: 100%;
@@ -97,13 +108,12 @@ summary {
 .nav a:hover,
 .footer-links a:hover,
 .quiet-link:hover,
-.release-meta a:hover,
 .faq a:hover {
   color: var(--foreground);
 }
 
 .hero {
-  padding: 4rem 0 7rem;
+  padding: 3rem 0 2.5rem;
 }
 
 .hero h1 {
@@ -126,8 +136,21 @@ summary {
 .cta-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
-  margin-top: 2.25rem;
+  gap: 1.25rem 2rem;
+  margin-top: 1.5rem;
+}
+
+.platform-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.platform-note {
+  margin: 0;
+  color: var(--secondary);
+  font-size: 0.75rem;
 }
 
 .button,
@@ -136,7 +159,7 @@ summary {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  min-height: 2.5rem;
+  min-height: 2.75rem;
   padding: 0.5rem 1rem;
   border: 1px solid transparent;
   border-radius: 0.5rem;
@@ -157,57 +180,31 @@ summary {
 }
 
 .button-secondary,
-.button-icon,
 .text-button {
   border-color: var(--border);
   background: transparent;
 }
 
 .button-secondary:hover,
-.button-icon:hover,
 .text-button:hover {
   background: rgba(255, 255, 255, 0.06);
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-.button-icon {
-  width: 2.5rem;
-  padding: 0;
-}
-
-.all-downloads {
-  display: inline-block;
-  margin-top: 0.65rem;
-  font-size: 0.75rem;
-}
-
-.release-meta {
+.hero-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem 0.6rem;
-  margin: 2rem 0 0;
-  color: var(--faint);
-  font-size: 0.75rem;
-}
-
-.release-meta span,
-.release-meta a {
-  color: var(--secondary);
-}
-
-.release-meta a {
-  text-decoration: underline;
-  text-decoration-color: rgba(255, 255, 255, 0.25);
-  text-underline-offset: 0.2em;
+  gap: 0.5rem 1.25rem;
+  margin-top: 1.25rem;
 }
 
 .product-overview {
-  padding-bottom: 10rem;
+  padding-bottom: 6rem;
 }
 
 .product-overview-copy {
   max-width: 42rem;
-  margin-bottom: 2.25rem;
+  margin-top: 2rem;
 }
 
 .product-overview-copy h2 {
@@ -275,6 +272,7 @@ summary {
 }
 
 .download-section,
+.self-host-section,
 .install-section,
 .faq-section {
   padding: 7rem 0;
@@ -301,7 +299,7 @@ summary {
 
 .download-row p {
   margin: 0.2rem 0 0;
-  color: var(--faint);
+  color: var(--secondary);
   font-size: 0.8125rem;
 }
 
@@ -312,8 +310,18 @@ summary {
   gap: 1rem;
 }
 
+.download-formats {
+  display: grid;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.download-formats .text-button {
+  min-width: 10rem;
+}
+
 .text-button {
-  min-height: 2.25rem;
+  min-height: 2.75rem;
   padding: 0.4rem 0.8rem;
 }
 
@@ -465,11 +473,11 @@ summary {
   .site-header {
     flex-direction: row;
     justify-content: space-between;
-    padding-top: 5rem;
+    padding-top: 2rem;
   }
 
   .hero {
-    padding: 4rem 0 8rem;
+    padding: 3.5rem 0 2.5rem;
   }
 
   .hero h1 {

--- a/website/tests/page.test.js
+++ b/website/tests/page.test.js
@@ -1,19 +1,103 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { renderLandingPage } from '../src/page.js';
-import { APPLE_GATEKEEPER_HELP_URL, DOWNLOADS, RELEASE } from '../src/releases.js';
+import {
+  APPLE_GATEKEEPER_HELP_URL,
+  DOCS_LINUX_INSTALL_URL,
+  DOWNLOADS,
+  GAJAE_CODE_URL,
+  RELEASE,
+  REPOSITORY_URL,
+} from '../src/releases.js';
+
+function section(html, id) {
+  const match = html.match(new RegExp(`<section[^>]*id="${id}"[^>]*>([\\s\\S]*?)</section>`));
+  assert.ok(match, `section #${id} exists`);
+  return match[1];
+}
 
 test('landing page exposes the pinned GitHub download buttons', () => {
   const html = renderLandingPage();
   assert.match(html, /id="download"/);
-  assert.match(html, new RegExp(DOWNLOADS.macosArm64.href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-  assert.match(html, new RegExp(DOWNLOADS.linuxServer.href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-  assert.match(html, /Download for Mac/);
+  for (const key of ['macosArm64', 'linuxDeb', 'linuxAppImage', 'linuxServer']) {
+    assert.ok(html.includes(`href="${DOWNLOADS[key].href}"`), `${key} download is linked`);
+    assert.ok(html.includes(`href="${DOWNLOADS[key].checksumHref}"`), `${key} checksum is linked`);
+  }
+  assert.match(html, /Download for macOS/);
+  assert.match(html, /Download for Linux/);
   assert.equal(html.includes('Windows용 내려받기'), false);
   assert.equal(html.includes('Download for Windows'), false);
   assert.equal(html.includes('/latest/download/'), false);
   assert.match(html, new RegExp(RELEASE.tag.replace('.', '\\.')));
+});
+
+test('introduces the desktop app for Gajae Code without positioning it as a separate agent', () => {
+  const hero = section(renderLandingPage(), 'top');
+  assert.match(hero, /<h1>The desktop app<br \/>for Gajae Code\.<\/h1>/);
+  assert.match(hero, /Open projects, resume sessions, and review changes—all in one local workspace\./);
+  assert.ok(hero.includes(`href="${GAJAE_CODE_URL}">About Gajae Code</a>`));
+});
+
+test('makes the two desktop platforms primary and source and server setup secondary', () => {
+  const hero = section(renderLandingPage(), 'top');
+  const primary = hero.slice(hero.indexOf('class="cta-row"'), hero.indexOf('class="hero-links"'));
+  assert.ok(primary.includes(`href="${DOWNLOADS.macosArm64.href}"`));
+  assert.match(primary, /href="#linux-download"/);
+  assert.equal(primary.includes(DOWNLOADS.linuxServer.href), false);
+  assert.equal(primary.includes(REPOSITORY_URL + '"'), false);
+  assert.equal(hero.includes('button-icon'), false);
+  assert.match(hero, /href="#self-host">Server setup/);
+  assert.ok(hero.includes(`href="${REPOSITORY_URL}">Source code</a>`));
+});
+
+test('separates the Linux desktop packages from self-hosted server downloads', () => {
+  const html = renderLandingPage();
+  const desktop = section(html, 'download');
+  const selfHost = section(html, 'self-host');
+  assert.match(desktop, /Linux desktop/);
+  assert.match(desktop, /Download \.deb/);
+  assert.match(desktop, /Download AppImage/);
+  assert.ok(desktop.includes(DOCS_LINUX_INSTALL_URL));
+  assert.ok(desktop.includes(DOWNLOADS.linuxDeb.href));
+  assert.ok(desktop.includes(DOWNLOADS.linuxAppImage.href));
+  assert.equal(desktop.includes(DOWNLOADS.linuxServer.href), false);
+  assert.match(desktop, /Intel Mac and Windows builds are not available yet\./);
+  assert.equal(html.includes('Linux desktop builds are not available yet'), false);
+  assert.ok(selfHost.includes(DOWNLOADS.linuxServer.href));
+  assert.match(selfHost, /Requires Node\.js 22\.22\.2\+ \(22\.x\)/);
+  assert.equal(selfHost.includes(DOWNLOADS.linuxDeb.href), false);
+});
+
+test('gives each checksum link a distinct accessible name', () => {
+  const html = renderLandingPage();
+  for (const [key, label] of [
+    ['macosArm64', 'macOS DMG'],
+    ['linuxDeb', 'Linux .deb'],
+    ['linuxAppImage', 'Linux AppImage'],
+    ['linuxServer', 'Linux server archive'],
+  ]) {
+    assert.ok(html.includes(`href="${DOWNLOADS[key].checksumHref}" aria-label="SHA-256 for ${label}"`));
+  }
+});
+
+test('every in-page link and accessibility reference has a unique target', () => {
+  const html = renderLandingPage();
+  const ids = [...html.matchAll(/\bid="([^"]+)"/g)].map((match) => match[1]);
+  assert.equal(new Set(ids).size, ids.length);
+  for (const [, target] of html.matchAll(/(?:href="#|aria-describedby="|aria-labelledby=")([^"]+)"/g)) {
+    assert.ok(ids.includes(target), `#${target} exists`);
+  }
+  assert.match(html, /id="linux-download" tabindex="-1"/);
+});
+
+test('keeps page and social metadata aligned with the desktop app positioning', () => {
+  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  assert.match(html, /<title>Gajae Code App — The desktop app for Gajae Code<\/title>/);
+  assert.match(html, /property="og:title" content="Gajae Code App — The desktop app for Gajae Code"/);
+  assert.match(html, /Available for macOS and Linux\./);
+  assert.equal(html.includes('with a desktop'), false);
 });
 
 test('states that the macOS beta is notarized and keeps the legacy Gatekeeper path for older builds', () => {
@@ -42,4 +126,14 @@ test('uses screenshots of the current release and none of the retired media', ()
   assert.match(html, /Match the model to the task\./);
   assert.equal(html.includes('Sol'), false);
   assert.equal(html.includes('Daymark'), false);
+});
+
+test('puts the real session screenshot immediately after the hero and before its explanation', () => {
+  const html = renderLandingPage();
+  const overview = section(html, 'features');
+  assert.match(overview, /^\s*<img[^>]+session-review\.jpg[^>]+fetchpriority="high"/);
+  assert.ok(overview.indexOf('session-review.jpg') < overview.indexOf('product-overview-copy'));
+  assert.match(html, /<\/section>\s*<section class="product-overview"/);
+  assert.match(html, /permission-card\.jpg[^>]+loading="lazy"/);
+  assert.match(html, /model-picker\.jpg[^>]+loading="lazy"/);
 });

--- a/website/tests/releases.test.js
+++ b/website/tests/releases.test.js
@@ -8,6 +8,8 @@ import {
   RELEASES_URL,
   buildDownloads,
   checksumName,
+  desktopAppImageName,
+  desktopDebName,
   desktopDmgName,
   downloadUrl,
   serverArchiveName,
@@ -26,6 +28,8 @@ test('pins the release the repository cut and its GitHub download URLs', () => {
   assert.equal(RELEASE.version, appVersion);
   assert.equal(RELEASE.tag, `v${appVersion}`);
   assert.equal(desktopDmgName(), `gajae-app-desktop-${appVersion}-macos-arm64.dmg`);
+  assert.equal(desktopDebName(), `gajae-app-desktop-${appVersion}-linux-x64.deb`);
+  assert.equal(desktopAppImageName(), `gajae-app-desktop-${appVersion}-linux-x64.AppImage`);
   assert.equal(serverArchiveName(), `gajae-app-server-${appVersion}-linux-x64-node22.tar.gz`);
   assert.equal(
     downloadUrl(desktopDmgName()),
@@ -36,6 +40,39 @@ test('pins the release the repository cut and its GitHub download URLs', () => {
     `${RELEASES_URL}/download/v${appVersion}/${checksumName(desktopDmgName())}`,
   );
   assert.match(DOWNLOADS.macosArm64.verifyCommand, /shasum -a 256 -c /);
+});
+
+test('publishes both Linux desktop formats with a matching checksum and verification command', () => {
+  for (const [key, fileName] of [
+    ['linuxDeb', desktopDebName()],
+    ['linuxAppImage', desktopAppImageName()],
+  ]) {
+    const download = DOWNLOADS[key];
+    assert.equal(download.label, fileName);
+    assert.equal(download.href, `${RELEASES_URL}/download/${RELEASE.tag}/${fileName}`);
+    assert.equal(download.checksumHref, `${download.href}.sha256`);
+    assert.equal(download.checksumFile, `${fileName}.sha256`);
+    assert.equal(download.verifyCommand, `sha256sum --check ${fileName}.sha256`);
+  }
+});
+
+test('keeps every artifact and checksum on the supplied release when the version changes', () => {
+  const release = { version: '9.9.9-test', tag: 'v9.9.9-test' };
+  const downloads = buildDownloads(release);
+  assert.equal(downloads.tagUrl, `${RELEASES_URL}/tag/${release.tag}`);
+  for (const [key, suffix] of [
+    ['macosArm64', 'desktop-9.9.9-test-macos-arm64.dmg'],
+    ['linuxDeb', 'desktop-9.9.9-test-linux-x64.deb'],
+    ['linuxAppImage', 'desktop-9.9.9-test-linux-x64.AppImage'],
+    ['linuxServer', 'server-9.9.9-test-linux-x64-node22.tar.gz'],
+  ]) {
+    const download = downloads[key];
+    assert.equal(download.label, `gajae-app-${suffix}`);
+    assert.equal(download.href, `${RELEASES_URL}/download/${release.tag}/${download.label}`);
+    assert.equal(download.checksumHref, `${download.href}.sha256`);
+    assert.equal(download.checksumFile, `${download.label}.sha256`);
+    assert.ok(download.verifyCommand.endsWith(download.checksumFile));
+  }
 });
 
 test('does not invent Windows or Intel desktop artifacts', () => {


### PR DESCRIPTION
## Summary

- Keep the product positioned as the desktop app for Gajae Code, with matching page and social metadata.
- Put visible macOS and Linux download actions ahead of source/server options, and bring the existing real-session screenshot directly below the hero.
- Add the published Linux x64 DEB and AppImage artifacts and their individual checksums; separate desktop installers from the self-hosted web/server options.
- Preserve the existing visual style, release pin, screenshots, dependencies, and GitHub Pages deployment.

## Validation

- `npm test --prefix website`: 14 tests passed, covering release filenames, checksum/version consistency, positioning, section order, accessibility references, and download separation.
- `npm run build --prefix website`: passed.
- `npm run verify`: passed (existing environment-gated skips unchanged).
- All four published beta.9 artifacts responded HTTP 200; all four SHA-256 sidecars responded HTTP 200 and named the corresponding artifact.
- Browser review at desktop, tablet, and narrow/mobile viewport sizes: no document horizontal overflow; first screenshot visible within the initial desktop/mobile view; Linux and server anchors navigate to the correct sections; Linux target receives focus; no browser console errors.

Only six website files change. App, release, and other concurrent work are untouched. No dependency or hosting migration is included.
