### PR TITLE
fix(release): classify bundled iOS prebuild resources

### DIFF
--- a/scripts/release/MANUAL-RELEASE.md
+++ b/scripts/release/MANUAL-RELEASE.md
@@ -39,8 +39,11 @@ Existing assets are never removed or replaced to make the set pass.
 
 ## Verify the local DMG before parent-owned smoke/GUI acceptance
 
-From the frozen release checkout, after signing/notarization/stapling are
-complete, use the existing helper with the explicit manual flag:
+After signing/notarization/stapling are complete, use the helper with the
+explicit manual flag. A separately versioned verifier-only correction does
+not change the frozen app/Linux source or release-tag target. For beta.10 those
+remain `a6b06a25bdcc8fc7e4980175fc757d93b28becc5`; record the verifier revision
+separately, and read identity/config/manifest pins from that frozen source.
 
 ```js
 import { createHash } from 'node:crypto';
@@ -49,7 +52,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { verifyMacosRelease } from './scripts/release/local-release-macos.mjs';
 
-// Verify HEAD and these source files against the frozen commit first.
+// Verify these source files against the frozen release commit first;
+// verifier-only HEAD may differ and must be recorded separately.
 const source = JSON.parse(await readFile('package.json', 'utf8'));
 const config = JSON.parse(await readFile('src-tauri/tauri.conf.json', 'utf8'));
 const runtimeManifestSha256 = createHash('sha256')
@@ -65,7 +69,8 @@ const verified = await verifyMacosRelease({
   manualDisabled: true,
   runtimeManifestSha256,
 });
-console.log(JSON.stringify({ root, copiedApp: verified.copiedApp, buildInfo: verified.buildInfo }, null, 2));
+console.log(JSON.stringify({ root, copiedApp: verified.copiedApp,
+  buildInfo: verified.buildInfo, deployment: verified.deployment }, null, 2));
 ```
 
 Do not pass `updaterArchivePath` with `manualDisabled: true`; even a null or
@@ -76,8 +81,19 @@ The helper verifies the DMG and both mounted/copied apps: expected Developer ID
 team, hardened app signatures, staples, Gatekeeper, package and desktop versions,
 arm64 executables, and the pinned macOS minimum. Every inventoried regular file
 is checked for Mach-O magic (including universal binaries and extensionless
-helpers); every discovered binary must have supported macOS loader stamps no
-newer than the declared minimum. Named required runtimes/modules remain required.
+helpers). macOS binaries must have supported macOS loader stamps no newer than
+the declared minimum, including any MACOS binary placed in an iOS folder.
+The sole non-Mac resource exception is beneath the canonical
+`Contents/Resources/resources/server-payload/node_modules/` path:
+`bare-*/prebuilds/ios-(arm64|x64)(-simulator)?/*.bare`. Each discovered resource
+is still inspected with vtool and must have structurally valid, uniform `IOS`
+stamps for device folders or `IOSSIMULATOR` stamps for simulator folders.
+Unknown platforms, malformed/duplicate/mixed evidence, mismatched folders and
+foreign binaries anywhere else fail. Named required runtimes/modules remain required.
+`deployment.nonMacResourceCount` and `deployment.nonMacResources` record the
+inspected exclusions (path, platform and minimum versions), separately from
+macOS-only `deployment.stamps` and `maximumStampedMinimumSystemVersion`.
+These resource exclusions are not macOS runtime qualification or a signature exemption.
 Full mounted/copy inventories must match in bytes, modes and internal symlinks.
 
 Only **after all copied-app validation** does the helper execute

--- a/scripts/release/local-release-macos.mjs
+++ b/scripts/release/local-release-macos.mjs
@@ -35,6 +35,8 @@ const REQUIRED_MACHO_PATHS = Object.freeze([
   'Contents/Resources/resources/server-payload/dist-native/bun',
   'Contents/Resources/resources/server-payload/dist-native/gajae-core',
 ]);
+const PAYLOAD_MODULES_PREFIX = `${PRODUCT_NAME}.app/Contents/Resources/resources/server-payload/node_modules/`;
+const IOS_BARE_PREBUILD = /^bare-[a-z0-9][a-z0-9._-]*\/prebuilds\/ios-(?:arm64|x64)(-simulator)?\/[^/]+\.bare$/;
 
 function strictMacosVersion(value, label) {
   requireValue(typeof value === 'string' && MACOS_VERSION.test(value)
@@ -94,46 +96,77 @@ async function nativeMachOPaths(app, inventory) {
  * Mach-O load commands; this parser only validates its bounded textual output
  * and never interprets binary bytes itself.
  */
-export function parseVtoolBuildMinimums(output, label = 'Mach-O') {
+function parseVtoolBuildStamps(output, label) {
   requireValue(typeof output === 'string' && Buffer.byteLength(output, 'utf8') > 0
     && Buffer.byteLength(output, 'utf8') <= MAX_VTOOL_OUTPUT_BYTES,
   `${label} vtool output is missing or oversized.`);
   const lines = output.split(/\r?\n/);
-  const commands = [];
+  const stamps = [];
+  const slices = new Set();
+  let filename;
+  let universal;
   let current;
-  for (const line of lines) {
-    if (/^\s*cmd(?:\s|$)/.test(line)) {
-      const command = /^\s*cmd\s+([A-Za-z0-9_]+)\s*$/.exec(line);
-      requireValue(command, `${label} has a malformed load-command line.`);
-      if (current) commands.push(current);
-      current = { name: command[1], platform: undefined, minos: undefined };
-      continue;
-    }
-    if (!current) continue;
-    const platform = /^\s*platform\s+([A-Za-z0-9_]+)\s*$/.exec(line);
-    if (platform) {
-      requireValue(current.platform === undefined, `${label} has duplicate vtool platform evidence.`);
-      current.platform = platform[1];
-      continue;
-    }
-    const minos = /^\s*minos\s+([0-9]+(?:\.[0-9]+){1,2})\s*$/.exec(line);
-    if (minos) {
-      requireValue(current.minos === undefined, `${label} has duplicate vtool minimum evidence.`);
-      current.minos = minos[1];
-    }
-  }
-  if (current) commands.push(current);
-  requireValue(commands.length > 0, `${label} has no LC_BUILD_VERSION evidence.`);
-  requireValue(commands.every(command => command.name === 'LC_BUILD_VERSION'),
-    `${label} contains an unsupported load command; only LC_BUILD_VERSION is accepted.`);
-  const minimums = [];
-  for (const stamp of commands) {
-    requireValue(stamp.platform === 'MACOS' && stamp.minos !== undefined,
+  const finishSlice = () => {
+    requireValue(current?.cmd === 'LC_BUILD_VERSION' && current.platform !== undefined && current.minos !== undefined,
       `${label} has missing or unsupported LC_BUILD_VERSION evidence.`);
-    strictMacosVersion(stamp.minos, `${label} minos`);
-    minimums.push(stamp.minos);
+    requireValue(['MACOS', 'IOS', 'IOSSIMULATOR'].includes(current.platform),
+      `${label} has unsupported LC_BUILD_VERSION platform evidence.`);
+    strictMacosVersion(current.minos, `${label} ${current.platform} minos`);
+    stamps.push(Object.freeze({ platform: current.platform, minos: current.minos }));
+  };
+  for (const line of lines) {
+    if (line.trim() === '') continue;
+    const header = /^(\S.*?)(?: \(architecture ([A-Za-z0-9_]+)\))?:$/.exec(line);
+    if (header) {
+      if (filename !== undefined) finishSlice();
+      const isUniversal = header[2] !== undefined;
+      const slice = header[2] ?? 'thin';
+      requireValue((filename === undefined || filename === header[1])
+        && (universal === undefined || universal === isUniversal) && !slices.has(slice),
+      `${label} has duplicate or inconsistent vtool slice evidence.`);
+      filename = header[1];
+      universal = isUniversal;
+      slices.add(slice);
+      current = undefined;
+      continue;
+    }
+    if (/^Load command (?:0|[1-9]\d*)$/.test(line)) {
+      requireValue(filename !== undefined && current === undefined,
+        `${label} has duplicate or unsupported load-command evidence.`);
+      current = {};
+      continue;
+    }
+    const field = /^\s*(cmd|platform|minos|cmdsize|sdk|ntools)\s+(\S+)\s*$/.exec(line);
+    if (field) {
+      const [, key, value] = field;
+      requireValue(current !== undefined && (key === 'cmd' || current.cmd === 'LC_BUILD_VERSION'),
+        `${label} has misplaced LC_BUILD_VERSION evidence.`);
+      requireValue(current[key] === undefined, `${label} has duplicate vtool ${key} evidence.`);
+      if (key === 'cmd') requireValue(value === 'LC_BUILD_VERSION', `${label} contains an unsupported load command.`);
+      else if (key === 'platform') requireValue(/^[A-Z][A-Z0-9_]*$/.test(value), `${label} has malformed platform evidence.`);
+      else requireValue((key === 'cmdsize' || key === 'ntools' ? /^(0|[1-9]\d*)$/ : /^\d+(?:\.\d+){1,2}$/).test(value),
+        `${label} has malformed vtool ${key} evidence.`);
+      current[key] = value;
+      continue;
+    }
+    // Linker/tool metadata is not deployment evidence, but malformed or
+    // unrecognized lines must not hide an extra platform/minimum stamp.
+    requireValue(current?.cmd === 'LC_BUILD_VERSION'
+      && /^\s*(?:tool\s+[A-Za-z0-9_]+|version\s+\d+(?:\.\d+){1,2})\s*$/.test(line),
+    `${label} has malformed vtool output or LC_BUILD_VERSION evidence.`);
   }
-  return Object.freeze(minimums);
+  finishSlice();
+  requireValue(stamps.every(stamp => stamp.platform === stamps[0].platform),
+    `${label} has mixed LC_BUILD_VERSION platforms.`);
+  return Object.freeze(stamps);
+}
+
+/** Public parser remains strictly macOS; resource classification is internal. */
+export function parseVtoolBuildMinimums(output, label = 'Mach-O') {
+  const stamps = parseVtoolBuildStamps(output, label);
+  requireValue(stamps.every(stamp => stamp.platform === 'MACOS'),
+    `${label} has missing or unsupported LC_BUILD_VERSION evidence.`);
+  return Object.freeze(stamps.map(stamp => stamp.minos));
 }
 
 /**
@@ -149,6 +182,7 @@ export async function verifyMacosDeploymentFloor({
   const declared = strictMacosVersion(minimumSystemVersion, 'minimumSystemVersion');
   const paths = await nativeMachOPaths(app, inventory);
   const stamps = [];
+  const nonMacResources = [];
   for (const item of paths) {
     const result = await run('xcrun', ['vtool', '-show-build', item.absolute], {
       maxOutputBytes: MAX_VTOOL_OUTPUT_BYTES,
@@ -158,7 +192,18 @@ export async function verifyMacosDeploymentFloor({
     `${item.path} vtool result has an invalid shape.`);
     requireValue(result.stderr === '', `${item.path} vtool wrote diagnostics to stderr.`);
     const output = result.stdout;
-    const minimums = parseVtoolBuildMinimums(output, item.path);
+    const buildStamps = parseVtoolBuildStamps(output, item.path);
+    const platform = buildStamps[0].platform;
+    if (platform !== 'MACOS') {
+      const resource = item.path.startsWith(PAYLOAD_MODULES_PREFIX)
+        ? IOS_BARE_PREBUILD.exec(item.path.slice(PAYLOAD_MODULES_PREFIX.length)) : null;
+      requireValue(resource && platform === (resource[1] ? 'IOSSIMULATOR' : 'IOS'),
+        `${item.path} has unsupported foreign platform ${platform} outside its matching iOS bare prebuild resource path.`);
+      nonMacResources.push(Object.freeze({ path: item.path, platform,
+        minimumSystemVersions: Object.freeze(buildStamps.map(stamp => stamp.minos)) }));
+      continue;
+    }
+    const minimums = buildStamps.map(stamp => stamp.minos);
     for (const minimum of minimums) {
       const parsed = strictMacosVersion(minimum, `${item.path} minos`);
       requireValue(semver.lte(parsed.parsed, declared.parsed),
@@ -173,6 +218,8 @@ export async function verifyMacosDeploymentFloor({
         ? item.minimumSystemVersion : max
     ), '0.0'),
     stamps: Object.freeze(stamps),
+    nonMacResourceCount: nonMacResources.length,
+    nonMacResources: Object.freeze(nonMacResources),
   });
 }
 
@@ -320,6 +367,7 @@ export async function verifyMacosRelease({
   let verificationError;
   let verificationResult;
   let extracted;
+  let copiedDeployment;
   try {
     await run('hdiutil', ['attach', dmg, '-nobrowse', '-readonly', '-mountpoint', mount]);
     const mountedApp = join(mount, `${PRODUCT_NAME}.app`);
@@ -341,9 +389,10 @@ export async function verifyMacosRelease({
     for (const app of [mountedApp, copiedApp, ...(extracted ? [extracted.appPath] : [])]) {
       const appInventory = app === copiedApp ? copiedInventory
         : app === extracted?.appPath ? extracted.inventory : undefined;
-      await verifyMacosApp({
+      const verifiedApp = await verifyMacosApp({
         app, teamId, version, desktopVersion, minimumSystemVersion, inventory: appInventory,
       }, { run });
+      if (app === copiedApp) copiedDeployment = verifiedApp.deployment;
     }
     if (manualDisabled) {
       // No UI, browser IPC, QA mode or lifecycle initialization. This early
@@ -358,9 +407,11 @@ export async function verifyMacosRelease({
       const buildInfo = assertManualBuildInfo(await readUpdaterSidecar(output, MAX_BUILD_INFO_BYTES),
         { version, desktopVersion, runtimeManifestSha256, payloadRuntimeManifestSha256 });
       compareAppInventories(copiedInventory, await inventoryApp(copiedApp));
-      verificationResult = { copiedApp, inventory: copiedInventory, buildInfo, payloadRuntimeManifestSha256, updateMode: 'disabled' };
+      verificationResult = { copiedApp, inventory: copiedInventory, deployment: copiedDeployment,
+        buildInfo, payloadRuntimeManifestSha256, updateMode: 'disabled' };
     } else {
-      verificationResult = { copiedApp, extractedApp: extracted.appPath, inventory: copiedInventory, archive: extracted.archive };
+      verificationResult = { copiedApp, extractedApp: extracted.appPath, inventory: copiedInventory,
+        deployment: copiedDeployment, archive: extracted.archive };
     }
   } catch (error) {
     verificationError = error;

--- a/scripts/release/local-release-macos.test.mjs
+++ b/scripts/release/local-release-macos.test.mjs
@@ -18,6 +18,30 @@ import { createUpdaterArchive, inventoryApp } from './updater-archive.mjs';
 
 const teamId = 'AB12345678';
 const signature = `Authority=Developer ID Application: Fixture (${teamId})\nTeamIdentifier=${teamId}\nCodeDirectory v=20500 size=400 flags=0x10000(runtime) hashes=12\n`;
+const payloadModules = 'Contents/Resources/resources/server-payload/node_modules';
+const simulatorResource = `${payloadModules}/bare-fs/prebuilds/ios-arm64-simulator/bare-fs.bare`;
+
+function vtoolStamp(platform, minimum = '14.0', header = 'x:') {
+  return `${header}\nLoad command 9\n      cmd LC_BUILD_VERSION\n  cmdsize 32\n platform ${platform}\n    minos ${minimum}\n      sdk 17.5\n   ntools 1\n     tool LD\n  version 1053.12\n`;
+}
+
+async function addMachO(state, app, relativePath, output) {
+  const path = join(app, relativePath);
+  await mkdir(join(path, '..'), { recursive: true });
+  await writeFile(path, Buffer.from('cffaedfe00000000', 'hex'), { mode: 0o600 });
+  state.vtoolOutputByPath ??= new Map();
+  state.vtoolOutputByPath.set(path, output);
+  return path;
+}
+
+async function deploymentFixture(t) {
+  const state = await fixture(t);
+  await state.run('hdiutil', ['attach']);
+  const app = join(state.input.root, 'mount/Gajae Code App.app');
+  return { state, app, verify: async () => verifyMacosDeploymentFloor({
+    app, minimumSystemVersion: '13.0', inventory: await inventoryApp(app),
+  }, { run: state.run }) };
+}
 
 async function fixture(t) {
   const root = await realpath(await mkdtemp(join(tmpdir(), 'gajae-macos-validation-test-')));
@@ -60,6 +84,7 @@ async function fixture(t) {
         await mkdir(join(file, '..'), { recursive: true });
         await writeFile(file, 'Mach-O fixture');
       }
+      if (state.afterMount) await state.afterMount(app);
     }
     if (program === 'ditto') {
       await cp(args[0], args[1], { recursive: true });
@@ -86,6 +111,7 @@ async function fixture(t) {
     if (program === 'codesign' && args[0] === '--display') return { stdout: '', stderr: state.signature ?? signature };
     if (program === 'spctl') return { stdout: '', stderr: `${args.at(-1)}: accepted\nsource=Notarized Developer ID\n` };
     if (program === 'xcrun' && args[0] === 'vtool') {
+      if (state.vtoolOutputByPath?.has(args.at(-1))) return { stdout: state.vtoolOutputByPath.get(args.at(-1)), stderr: '' };
       if (state.vtoolOutput !== undefined) return { stdout: state.vtoolOutput, stderr: '' };
       const minimum = state.vtoolMinimumByPath?.get(args.at(-1)) ?? state.vtoolMinimum ?? '13.0';
       return {
@@ -196,6 +222,135 @@ test('deployment floor includes dylib and shared-object runtime modules', async 
   }, { run: state.run }), /libfixture\.dylib|requires macOS 14\.0/);
 });
 
+test('only matching vendor iOS bare prebuilds are reported separately from qualified macOS stamps', async t => {
+  const { state, app, verify } = await deploymentFixture(t);
+  const expected = [];
+  for (const arch of ['arm64', 'x64']) {
+    for (const simulator of [false, true]) {
+      const path = `${payloadModules}/bare-fs/prebuilds/ios-${arch}${simulator ? '-simulator' : ''}/bare-fs.bare`;
+      const platform = simulator ? 'IOSSIMULATOR' : 'IOS';
+      await addMachO(state, app, path, vtoolStamp(platform));
+      expected.push({ path: `Gajae Code App.app/${path}`, platform, minimumSystemVersions: ['14.0'] });
+    }
+  }
+  const result = await verify();
+  assert.equal(result.nonMacResourceCount, 4);
+  assert.deepEqual(result.nonMacResources, expected.sort((a, b) => a.path < b.path ? -1 : 1));
+  assert.equal(result.maximumStampedMinimumSystemVersion, '13.0');
+  assert.equal(result.stamps.length, 7);
+  assert.ok(result.stamps.every(stamp => !stamp.path.endsWith('.bare') && stamp.minimumSystemVersion === '13.0'));
+  assert.equal(state.calls.filter(call => call.args[0] === 'vtool').length, 11);
+});
+
+test('uniform universal slices count as one non-Mac resource; public parser remains strictly MACOS', async t => {
+  const { state, app, verify } = await deploymentFixture(t);
+  const output = vtoolStamp('IOSSIMULATOR', '14.0', 'x (architecture arm64):')
+    + vtoolStamp('IOSSIMULATOR', '15.0', 'x (architecture x86_64):');
+  await addMachO(state, app, simulatorResource, output);
+  const result = await verify();
+  assert.equal(result.nonMacResourceCount, 1);
+  assert.deepEqual(result.nonMacResources[0].minimumSystemVersions, ['14.0', '15.0']);
+  for (const platform of ['IOS', 'IOSSIMULATOR', 'TVOS', 'UNKNOWN']) {
+    assert.throws(() => parseVtoolBuildMinimums(vtoolStamp(platform)), /unsupported/);
+  }
+  assert.throws(() => parseVtoolBuildMinimums(output, 'resource', { allowForeign: true }), /unsupported/);
+  assert.deepEqual(parseVtoolBuildMinimums(vtoolStamp('MACOS', '12.0', 'x (architecture arm64):')
+    + vtoolStamp('MACOS', '13.0', 'x (architecture x86_64):')), ['12.0', '13.0']);
+});
+
+test('foreign binaries outside the exact canonical resource path fail closed', async t => {
+  for (const path of [
+    'Contents/Resources/node_modules/bare-fs/prebuilds/ios-arm64-simulator/bare-fs.bare',
+    'Contents/Resources/server-payload/node_modules/bare-fs/prebuilds/ios-arm64-simulator/bare-fs.bare',
+    `${payloadModules}/other/prebuilds/ios-arm64-simulator/bare-fs.bare`,
+    `${payloadModules}/@vendor/bare-fs/prebuilds/ios-arm64-simulator/bare-fs.bare`,
+    `${payloadModules}/nested/node_modules/bare-fs/prebuilds/ios-arm64-simulator/bare-fs.bare`,
+    `${payloadModules}/bare-fs/prebuilds/darwin-arm64/bare-fs.bare`,
+    `${payloadModules}/bare-fs/prebuilds/ios-armv7-simulator/bare-fs.bare`,
+    `${payloadModules}/bare-fs/prebuilds/ios-arm64-simulator/nested/bare-fs.bare`,
+    `${payloadModules}/bare-fs/prebuilds/ios-arm64-simulator/bare-fs.node`,
+    `${simulatorResource}.backup`,
+    'Contents/Resources/unlisted-helper',
+  ]) {
+    await t.test(path, async t => {
+      const { state, app, verify } = await deploymentFixture(t);
+      await addMachO(state, app, path, vtoolStamp('IOSSIMULATOR'));
+      await assert.rejects(verify(), /unsupported foreign platform/);
+    });
+  }
+});
+
+test('iOS paths never exempt MACOS binaries from the declared macOS 13 floor', async t => {
+  const { state, app, verify } = await deploymentFixture(t);
+  const path = await addMachO(state, app, simulatorResource, vtoolStamp('MACOS'));
+  await assert.rejects(verify(), /bare-fs\.bare requires macOS 14\.0/);
+  state.vtoolOutputByPath.set(path, vtoolStamp('MACOS', '13.0'));
+  const result = await verify();
+  assert.equal(result.nonMacResourceCount, 0);
+  assert.deepEqual(result.nonMacResources, []);
+  assert.ok(result.stamps.some(stamp => stamp.path.endsWith(simulatorResource)));
+});
+
+test('iOS resources reject unexpected, malformed, duplicate and mixed platform evidence', async t => {
+  const valid = vtoolStamp('IOSSIMULATOR');
+  for (const [name, output] of [
+    ['device stamp in simulator folder', vtoolStamp('IOS')],
+    ['unknown platform', vtoolStamp('UNKNOWN')],
+    ['other foreign platform', vtoolStamp('TVOS')],
+    ['missing platform', valid.replace(' platform IOSSIMULATOR\n', '')],
+    ['missing minimum', valid.replace('    minos 14.0\n', '')],
+    ['invalid minimum', valid.replace('minos 14.0', 'minos 14.0garbage')],
+    ['unbounded minimum', valid.replace('minos 14.0', 'minos 1000.0')],
+    ['noncanonical minimum', valid.replace('minos 14.0', 'minos 014.0')],
+    ['duplicate platform', `${valid} platform IOSSIMULATOR\n`],
+    ['duplicate minimum', `${valid} minos 14.0\n`],
+    ['malformed extra platform', `${valid} platform MACOS garbage\n`],
+    ['malformed extra minimum', `${valid} minos invalid\n`],
+    ['orphan evidence', ` platform IOSSIMULATOR\n${valid}`],
+    ['missing load-command boundary', valid.replace('Load command 9\n', '')],
+    ['missing command', valid.replace('      cmd LC_BUILD_VERSION\n', '')],
+    ['duplicate command', `${valid} cmd LC_BUILD_VERSION\n`],
+    ['duplicate stamp in slice', `${valid}Load command 10\n cmd LC_BUILD_VERSION\n platform IOSSIMULATOR\n minos 14.0\n`],
+    ['duplicate thin slice', valid + valid],
+    ['duplicate architecture', vtoolStamp('IOSSIMULATOR', '14.0', 'x (architecture arm64):').repeat(2)],
+    ['truncated second slice', `${vtoolStamp('IOSSIMULATOR', '14.0', 'x (architecture arm64):')}x (architecture x86_64):\n`],
+    ['mixed iOS platforms', vtoolStamp('IOSSIMULATOR', '14.0', 'x (architecture arm64):')
+      + vtoolStamp('IOS', '14.0', 'x (architecture x86_64):')],
+    ['mixed Mac and iOS platforms', vtoolStamp('MACOS', '13.0', 'x (architecture arm64):')
+      + vtoolStamp('IOSSIMULATOR', '14.0', 'x (architecture x86_64):')],
+    ['unsupported legacy command', valid.replace('LC_BUILD_VERSION', 'LC_VERSION_MIN_IPHONEOS')],
+    ['unexpected text', `${valid}not vtool output\n`],
+  ]) {
+    await t.test(name, async t => {
+      const { state, app, verify } = await deploymentFixture(t);
+      await addMachO(state, app, simulatorResource, output);
+      await assert.rejects(verify(), /evidence|vtool|unsupported|bounded|mixed/);
+    });
+  }
+  const { state, app, verify } = await deploymentFixture(t);
+  await addMachO(state, app, simulatorResource.replace('-simulator', ''), valid);
+  await assert.rejects(verify(), /unsupported foreign platform/);
+});
+
+test('required executables and runtime modules never qualify as non-Mac resources', async t => {
+  for (const path of [
+    'Contents/MacOS/gajae-app-desktop',
+    'Contents/MacOS/gajae-app-server',
+    'Contents/Resources/resources/server-payload/dist-native/bun',
+    'Contents/Resources/resources/server-payload/dist-native/gajae-core',
+    `${payloadModules}/test-addon/addon.node`,
+    `${payloadModules}/@vscode/ripgrep/bin/rg`,
+    `${payloadModules}/node-pty/build/Release/spawn-helper`,
+  ]) {
+    await t.test(path, async t => {
+      const { state, app, verify } = await deploymentFixture(t);
+      await addMachO(state, app, simulatorResource, vtoolStamp('IOSSIMULATOR'));
+      await addMachO(state, app, path, vtoolStamp('IOS'));
+      await assert.rejects(verify(), /unsupported foreign platform/);
+    });
+  }
+});
+
 test('deployment floor rejects vtool diagnostics and malformed command results', async t => {
   const state = await fixture(t);
   const app = join(state.input.root, 'mount/Gajae Code App.app');
@@ -301,6 +456,8 @@ test('explicit manual mode validates DMG and both apps before the bounded copied
   assert.equal(result.updateMode, 'disabled');
   assert.equal(result.buildInfo.updateMode, 'disabled');
   assert.equal(result.buildInfo.runtimeManifestSha256, state.input.runtimeManifestSha256);
+  assert.equal(result.deployment.nonMacResourceCount, 0);
+  assert.equal(result.deployment.maximumStampedMinimumSystemVersion, '13.0');
   assert.equal(result.extractedApp, undefined);
   assert.ok((await readFile(join(result.copiedApp, 'Contents/MacOS/gajae-app-desktop'))).length > 0);
   const diagnosticIndex = state.calls.findIndex(call => call.args.includes('--desktop-build-info'));
@@ -315,6 +472,23 @@ test('explicit manual mode validates DMG and both apps before the bounded copied
   assert.equal(state.calls.filter(call => call.args[0] === '--desktop-build-info').length, 1);
   assert.equal(state.calls.at(-1).args[0], 'detach');
   assert.ok(!state.calls.some(call => call.args.some(arg => /--sign|--qa|--browser|\.app\.tar\.gz/.test(arg))));
+});
+
+test('manual release exposes inspected resource evidence from the validated copy', async t => {
+  const state = await manualFixture(t);
+  state.afterMount = async app => {
+    const output = vtoolStamp('IOSSIMULATOR');
+    await addMachO(state, app, simulatorResource, output);
+    state.vtoolOutputByPath.set(join(state.input.root, 'copy/Gajae Code App.app', simulatorResource), output);
+  };
+  const result = await state.execute();
+  assert.equal(result.deployment.nonMacResourceCount, 1);
+  assert.deepEqual(result.deployment.nonMacResources, [{
+    path: `Gajae Code App.app/${simulatorResource}`, platform: 'IOSSIMULATOR', minimumSystemVersions: ['14.0'],
+  }]);
+  assert.equal(result.deployment.maximumStampedMinimumSystemVersion, '13.0');
+  const resourceChecks = state.calls.filter(call => call.args[0] === 'vtool' && call.args.at(-1).endsWith(simulatorResource));
+  assert.equal(resourceChecks.length, 2);
 });
 
 test('manual flag is explicit, mutually exclusive with updater archives, and requires private root and source hash', async t => {


### PR DESCRIPTION
Verifier-only correction; release artifacts remain pinned to a6b06a25bdcc8fc7e4980175fc757d93b28becc5 and are not rebuilt or altered by this change.

The real signed beta.10 bundle contains vendor bare-* IOS/IOSSIMULATOR prebuild resources. They are not macOS runtime binaries. Classify only exact known payload vendor paths and uniform matching platform stamps separately. Keep exported parser macOS-only, and reject unknown/wrong/mixed/malformed evidence or a disguised MACOS binary above the declared floor. All signature, staple, Gatekeeper, inventory, hash, identity and disabled-build requirements remain enforced.

71 focused tests passed; targeted ESLint/diff checks passed. Actual signed app scan: 20 macOS stamps with maximum minimum 13.0, 9 separately recorded non-Mac resources. No app bytes or credentials changed. Parent will use this separately-versioned validation tool for final beta.10 artifact acceptance and publication.