### PR TITLE
fix: browser preview clarity, clipboard shortcuts, and archived sidebar rows

### DIFF
--- a/docs/BROWSER-CUA-VERIFICATION.md
+++ b/docs/BROWSER-CUA-VERIFICATION.md
@@ -28,6 +28,24 @@ and published beta.10 app is unchanged until a new versioned build is released.
 
 ## Implemented surface
 
+### Unreleased panel fixes — 2026-09-09
+
+- Preview sizing includes the viewer's device pixel ratio (bounded at 2×).
+  Screencast frames are no longer capped at 1440×900; pointer coordinates remain
+  in CSS pixels rather than physical image pixels.
+- With the preview focused, Ctrl/Cmd+C, X and V transfer plain text between the
+  viewer's clipboard and the remote page selection. Cut deletes only after a
+  successful local clipboard write and a matching remote selection check.
+  Delayed operations are bound to the originating tab.
+- Clipboard access requires the viewer's browser permission and a secure
+  context. This is user-triggered text transfer, not ambient system clipboard
+  synchronization; images, files and rich HTML are not transferred.
+- Real Chromium regression coverage decodes a 2000×1400 streamed frame for a
+  1000×700 CSS viewport at 2×, checks a bottom-right pointer target, and exercises
+  input/contenteditable copy, cut and paste, changed-selection refusal,
+  readonly controls and reactive input events.
+- These are source changes, not acceptance of a newly packaged or installed app.
+
 ### Unreleased panel fixes — 2026-09-07
 
 - The selected conversation watches `/ws/browser?sessionId=…&mode=state`
@@ -89,7 +107,8 @@ These fixes are unreleased. Published/installed beta.10 remains unchanged.
 
 The PoC intentionally excludes file upload, automatic download saving, browser
 extensions, existing Chrome profiles, force-quitting native apps, clipboard
-reading, file transfer, screen recording, and lock-screen control.
+reading through the CUA driver, file transfer, screen recording, and lock-screen
+control. The panel's explicit plain-text clipboard shortcuts are described above.
 
 ## Automated evidence
 

--- a/server/e2e/browser-sidecar.e2e.ts
+++ b/server/e2e/browser-sidecar.e2e.ts
@@ -230,7 +230,7 @@ test('real Chromium sidecar shares structured actions, tabs, and screencast stat
   const status = await sidecar.request('status') as { installed: boolean };
   assert.equal(status.installed, true, 'activate the Browser panel once before running this E2E');
 
-  const opened = await sidecar.request('session.open', 'browser-e2e', { url, allowDownload: false }) as { tabs: unknown[] };
+  const opened = await sidecar.request('session.open', 'browser-e2e', { url, allowDownload: false }) as { activeTabId: string; tabs: unknown[] };
   assert.equal(opened.tabs.length, 1);
   await sidecar.request('screencast.subscribe', 'browser-e2e');
   await sidecar.waitForEvent('frame');
@@ -267,6 +267,83 @@ test('real Chromium sidecar shares structured actions, tabs, and screencast stat
   assert.equal(resizedFrame.kind === 'event' && resizedFrame.payload.metadata && typeof resizedFrame.payload.metadata === 'object'
     ? (resizedFrame.payload.metadata as { deviceHeight?: number }).deviceHeight
     : undefined, 742);
+
+  const retinaFrameStart = sidecar.events.length;
+  await sidecar.request('browser.input', 'browser-e2e', {
+    input: { kind: 'viewport', width: 1000, height: 700, deviceScaleFactor: 2 },
+  });
+  assert.deepEqual(await runScript('({ width: innerWidth, height: innerHeight, scale: devicePixelRatio })'), {
+    value: { width: 1000, height: 700, scale: 2 },
+  });
+  const retinaFrame = await sidecar.waitForEvent('frame', 5_000, retinaFrameStart);
+  assert.equal(retinaFrame.kind, 'event');
+  if (retinaFrame.kind !== 'event') throw new Error('Expected a browser frame.');
+  const retinaSize = await runScript(`const image = new Image();
+    image.src = ${JSON.stringify(`data:image/jpeg;base64,${retinaFrame.payload.data}`)};
+    await image.decode();
+    ({ width: image.naturalWidth, height: image.naturalHeight });`);
+  assert.deepEqual(retinaSize, { value: { width: 2000, height: 1400 } },
+    'the streamed image must retain physical pixels beyond the old 1440×900 cap');
+  assert.equal((retinaFrame.payload.metadata as { deviceWidth: number }).deviceWidth, 1000);
+  assert.equal((retinaFrame.payload.metadata as { deviceHeight: number }).deviceHeight, 700);
+  await runScript(`const corner = document.createElement('button'); corner.id = 'retina-corner';
+    corner.style = 'position:fixed;right:0;bottom:0;width:40px;height:40px';
+    corner.onclick = () => { window.retinaClicked = true; }; document.body.append(corner);`);
+  for (const event of ['down', 'up']) {
+    await sidecar.request('browser.input', 'browser-e2e', {
+      input: { kind: 'mouse', event, x: 980, y: 680, button: 'left' },
+    });
+  }
+  assert.deepEqual(await runScript('window.retinaClicked'), { value: true },
+    'high-DPI preview input must reach the bottom-right CSS coordinates');
+
+  const clipboard = (input: Record<string, unknown>) => sidecar.request('browser.input', 'browser-e2e', {
+    input: { kind: 'clipboard', tabId: opened.activeTabId, ...input },
+  });
+  await runScript(`const input = document.querySelector('#name');
+    window.cutInputEvents = 0;
+    input.addEventListener('input', () => { window.cutInputEvents++; });
+    input.value = '복사할 텍스트'; input.focus(); input.select();`);
+  const copied = await clipboard({ event: 'read' }) as { text: string; selectionId: string };
+  assert.equal(copied.text, '복사할 텍스트');
+  assert.deepEqual(await runScript('document.querySelector("#name").value'), { value: '복사할 텍스트' },
+    'copy must not mutate the selected input');
+  await clipboard({ event: 'delete', text: copied.text, selectionId: copied.selectionId });
+  assert.deepEqual(await runScript('document.querySelector("#name").value'), { value: '' });
+  assert.deepEqual(await runScript('window.cutInputEvents'), { value: 1 },
+    'cut must notify reactive input handlers');
+  await clipboard({ event: 'paste', text: '붙여넣기 ✓' });
+  assert.deepEqual(await runScript('document.querySelector("#name").value'), { value: '붙여넣기 ✓' });
+  await runScript('document.querySelector("#name").select()');
+  const staleCopy = await clipboard({ event: 'read' }) as { text: string; selectionId: string };
+  await runScript('document.querySelector("#name").setSelectionRange(0, 1)');
+  assert.deepEqual(await clipboard({ event: 'delete', text: staleCopy.text, selectionId: staleCopy.selectionId }),
+    { accepted: true, deleted: false }, 'cut must not delete a changed selection');
+  await runScript('document.querySelector("#name").readOnly = true; document.querySelector("#name").select()');
+  const readonlyCopy = await clipboard({ event: 'read' }) as { text: string; editable: boolean; selectionId: string };
+  assert.equal(readonlyCopy.editable, false);
+  assert.deepEqual(await clipboard({ event: 'delete', text: readonlyCopy.text, selectionId: readonlyCopy.selectionId }),
+    { accepted: true, deleted: false });
+  await runScript('document.querySelector("#name").readOnly = false');
+  await runScript(`const password = document.createElement('input');
+    password.type = 'password'; password.value = 'private password'; password.id = 'password';
+    document.body.append(password); password.focus(); password.select();`);
+  const passwordCopy = await clipboard({ event: 'read' }) as { text: string; editable: boolean };
+  assert.equal(passwordCopy.text, '', 'password selections must never cross the clipboard bridge');
+  assert.equal(passwordCopy.editable, false);
+  await runScript('document.querySelector("#password").remove()');
+  await runScript(`const editable = document.createElement('div');
+    editable.id = 'editable'; editable.contentEditable = 'true';
+    editable.textContent = 'editable selection'; document.body.append(editable);
+    editable.focus(); const range = document.createRange(); range.selectNodeContents(editable);
+    getSelection().removeAllRanges(); getSelection().addRange(range);`);
+  const editableCopy = await clipboard({ event: 'read' }) as { text: string; selectionId: string };
+  assert.equal(editableCopy.text, 'editable selection');
+  await clipboard({ event: 'delete', text: editableCopy.text, selectionId: editableCopy.selectionId });
+  await clipboard({ event: 'paste', text: 'editable paste' });
+  assert.deepEqual(await runScript('document.querySelector("#editable").textContent'), { value: 'editable paste' });
+  await assert.rejects(clipboard({ event: 'paste', tabId: 'wrong-tab', text: 'must not insert' }), /browser tab changed/i);
+  assert.deepEqual(await runScript('document.querySelector("#editable").textContent'), { value: 'editable paste' });
 
   const observed = await sidecar.request('browser.command', 'browser-e2e', {
     command: { action: 'observe' },

--- a/server/modules/automation/browser-protocol.ts
+++ b/server/modules/automation/browser-protocol.ts
@@ -52,12 +52,39 @@ export type BrowserCommand =
 
 export type BrowserWaitUntil = 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
 
+/**
+ * Clipboard operations are deliberately two-phase for copy/cut. A read only
+ * observes the remote selection; the client writes that text to its own
+ * clipboard before asking the sidecar to delete the still-matching selection.
+ * The tab binding prevents a delayed local clipboard permission result from
+ * mutating a different active tab.
+ */
+export type BrowserClipboardInput =
+  | { kind: 'clipboard'; event: 'read'; tabId: string }
+  | { kind: 'clipboard'; event: 'delete'; tabId: string; text: string; selectionId: string }
+  | { kind: 'clipboard'; event: 'paste'; tabId: string; text: string };
+
 export type BrowserInput =
   | { kind: 'mouse'; event: 'move' | 'down' | 'up'; x: number; y: number; button?: 'left' | 'right' | 'middle'; clickCount?: number }
   | { kind: 'wheel'; x: number; y: number; deltaX: number; deltaY: number }
   | { kind: 'key'; event: 'down' | 'up'; key: string; code?: string; modifiers?: number }
   | { kind: 'text'; text: string }
-  | { kind: 'viewport'; width: number; height: number };
+  | { kind: 'viewport'; width: number; height: number; deviceScaleFactor?: number }
+  | BrowserClipboardInput;
+
+export function isBrowserClipboardInput(value: unknown): value is BrowserClipboardInput {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const input = value as Record<string, unknown>;
+  if (input.kind !== 'clipboard' || !safeSessionId(input.tabId)) return false;
+  if (input.event === 'read') return Object.keys(input).length === 3;
+  if (input.event === 'paste') return Object.keys(input).length === 4 && typeof input.text === 'string';
+  return input.event === 'delete'
+    && Object.keys(input).length === 5
+    && typeof input.text === 'string'
+    && typeof input.selectionId === 'string'
+    && input.selectionId.length > 0
+    && input.selectionId.length <= 2_048;
+}
 
 export type BrowserRequestMethod =
   | 'initialize'

--- a/server/modules/automation/browser-sidecar-keys.test.ts
+++ b/server/modules/automation/browser-sidecar-keys.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { toPuppeteerKeyInput } from './browser-sidecar.js';
+import { normalizeBrowserDeviceScaleFactor, toPuppeteerKeyInput } from './browser-sidecar.js';
+import { isBrowserClipboardInput } from './browser-protocol.js';
 
 test('maps editing and navigation keys to Puppeteer key inputs', () => {
   for (const key of [
@@ -28,4 +29,36 @@ test('maps function keys and rejects IME keys', () => {
   for (const key of ['Dead', 'Unidentified', 'Process']) {
     assert.equal(toPuppeteerKeyInput(key), null);
   }
+});
+
+test('bounds browser device scale factors without allowing invalid values', () => {
+  assert.equal(normalizeBrowserDeviceScaleFactor(undefined), 1);
+  assert.equal(normalizeBrowserDeviceScaleFactor(1.5), 1.5);
+  assert.equal(normalizeBrowserDeviceScaleFactor(4), 2);
+  assert.equal(normalizeBrowserDeviceScaleFactor(0), null);
+  assert.equal(normalizeBrowserDeviceScaleFactor(Number.NaN), null);
+});
+
+test('requires clipboard operations to bind their tab and phase payload', () => {
+  assert.equal(isBrowserClipboardInput({ kind: 'clipboard', event: 'read', tabId: 'tab-1' }), true);
+  assert.equal(isBrowserClipboardInput({
+    kind: 'clipboard',
+    event: 'delete',
+    tabId: 'tab-1',
+    text: 'selected',
+    selectionId: 'control:1:2',
+  }), true);
+  assert.equal(isBrowserClipboardInput({
+    kind: 'clipboard',
+    event: 'paste',
+    tabId: 'tab-1',
+    text: 'pasted',
+  }), true);
+  assert.equal(isBrowserClipboardInput({ kind: 'clipboard', event: 'read', tabId: 'other tab' }), false);
+  assert.equal(isBrowserClipboardInput({
+    kind: 'clipboard',
+    event: 'delete',
+    tabId: 'tab-1',
+    text: 'selected',
+  }), false);
 });

--- a/server/modules/automation/browser-sidecar.ts
+++ b/server/modules/automation/browser-sidecar.ts
@@ -43,6 +43,7 @@ import {
   serializeBrowserFrame,
   type BrowserCommand,
   type BrowserChildActivity,
+  isBrowserClipboardInput,
   type BrowserEventFrame,
   type BrowserInput,
   type BrowserRequestFrame,
@@ -81,6 +82,7 @@ type Tab = {
   screencasting: boolean;
   screencastListenerAttached: boolean;
   viewport: BrowserViewportSize;
+  deviceScaleFactor: number;
 };
 
 type Session = {
@@ -112,10 +114,27 @@ type AxNode = {
   value?: { value?: string | number | boolean };
 };
 
+type ClipboardSelection = {
+  text: string;
+  editable: boolean;
+  selectionId: string;
+};
+
 const CACHE_ROOT = process.env.GAJAE_BROWSER_CACHE_DIR ?? join(homedir(), '.gajae-app', 'browser', 'chromium');
 const PROFILE_ROOT = process.env.GAJAE_BROWSER_PROFILE_DIR ?? join(homedir(), '.gajae-app', 'browser', 'profile');
 const MAX_RUN_CODE_BYTES = 64 * 1024;
 const MAX_RESULT_TEXT = 256 * 1024;
+const DEFAULT_BROWSER_DEVICE_SCALE_FACTOR = 1;
+export const MAX_BROWSER_DEVICE_SCALE_FACTOR = 2;
+const MAX_CLIPBOARD_TEXT = 1024 * 1024;
+const MAX_BROWSER_FRAME_WIDTH = 5_120;
+const MAX_BROWSER_FRAME_HEIGHT = 3_200;
+
+export function normalizeBrowserDeviceScaleFactor(value: unknown): number | null {
+  if (value === undefined) return DEFAULT_BROWSER_DEVICE_SCALE_FACTOR;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  return Math.min(Math.max(Math.round(value * 100) / 100, DEFAULT_BROWSER_DEVICE_SCALE_FACTOR), MAX_BROWSER_DEVICE_SCALE_FACTOR);
+}
 
 /** Console-style page evaluation: preserve completion values and support top-level await. */
 export async function evaluateBrowserScript(cdp: Pick<CDPSession, 'send'>, code: string): Promise<unknown> {
@@ -469,9 +488,18 @@ export class BrowserRuntime {
           break;
         case 'fill':
           await this.focus(tab, command);
-          await page.keyboard.down(process.platform === 'darwin' ? 'Meta' : 'Control');
-          await page.keyboard.press('A');
-          await page.keyboard.up(process.platform === 'darwin' ? 'Meta' : 'Control');
+          await page.evaluate(() => {
+            const active = document.activeElement;
+            if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+              active.select();
+            } else if (active instanceof HTMLElement && active.isContentEditable) {
+              const selection = window.getSelection();
+              const range = document.createRange();
+              range.selectNodeContents(active);
+              selection?.removeAllRanges();
+              selection?.addRange(range);
+            }
+          });
           await page.keyboard.type(command.text);
           break;
         case 'select':
@@ -537,22 +565,52 @@ export class BrowserRuntime {
     }).promise;
   }
 
-  async input(sessionId: string, input: BrowserInput): Promise<{ accepted: true }> {
+  async input(sessionId: string, input: BrowserInput): Promise<Record<string, unknown>> {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error('session_not_found: Open the browser session first.');
     this.requireOpen(session);
     return this.track(session, async () => {
       this.requireOpen(session);
       const tab = this.activeTab(session);
+      if (input.kind === 'clipboard') {
+        if (!isBrowserClipboardInput(input)) {
+          throw new Error('invalid_clipboard: Clipboard input must bind to a valid browser tab.');
+        }
+        if (input.tabId !== tab.id) {
+          throw new Error('clipboard_target_changed: The browser tab changed before the clipboard operation completed.');
+        }
+        if (input.event === 'read') {
+          const selection = await this.readClipboardSelection(tab);
+          if (Buffer.byteLength(selection.text, 'utf8') > MAX_CLIPBOARD_TEXT) {
+            throw new Error('clipboard_too_large: The selected text is too large to copy.');
+          }
+          return { accepted: true, ...selection };
+        }
+        if (Buffer.byteLength(input.text, 'utf8') > MAX_CLIPBOARD_TEXT) {
+          throw new Error('clipboard_too_large: Clipboard text is too large.');
+        }
+        if (input.event === 'delete') {
+          const deleted = await this.deleteClipboardSelection(tab, input.text, input.selectionId);
+          return { accepted: true, deleted };
+        }
+        const cdp = await this.cdp(tab);
+        await cdp.send('Input.insertText', { text: input.text });
+        return { accepted: true };
+      }
       const cdp = await this.cdp(tab);
       if (input.kind === 'viewport') {
         const viewport = normalizeBrowserViewport(input.width, input.height);
         if (!viewport) throw new Error('invalid_viewport: Browser viewport dimensions must be positive finite numbers.');
-        if (viewport.width !== tab.viewport.width || viewport.height !== tab.viewport.height) {
+        const deviceScaleFactor = normalizeBrowserDeviceScaleFactor(input.deviceScaleFactor);
+        if (deviceScaleFactor === null) throw new Error('invalid_viewport: Device scale factor must be a positive finite number.');
+        if (viewport.width !== tab.viewport.width
+          || viewport.height !== tab.viewport.height
+          || deviceScaleFactor !== tab.deviceScaleFactor) {
           const resumeScreencast = tab.screencasting && session.subscribed && session.activeTabId === tab.id;
           if (resumeScreencast) await this.stopScreencast(tab);
+          await this.applyViewport(tab, viewport, deviceScaleFactor, cdp);
           tab.viewport = viewport;
-          await tab.page.setViewport({ ...viewport, deviceScaleFactor: 1 });
+          tab.deviceScaleFactor = deviceScaleFactor;
           if (resumeScreencast) await this.startScreencast(session, tab);
         }
       } else if (input.kind === 'mouse') {
@@ -664,7 +722,10 @@ export class BrowserRuntime {
         browser = await launchBrowserWithLinuxFallback(installed.executablePath, {
           userDataDir: profilePath,
           headless: true,
-          defaultViewport: { ...DEFAULT_BROWSER_VIEWPORT, deviceScaleFactor: 1 },
+          defaultViewport: {
+            ...DEFAULT_BROWSER_VIEWPORT,
+            deviceScaleFactor: DEFAULT_BROWSER_DEVICE_SCALE_FACTOR,
+          },
           downloadBehavior: { policy: 'deny' },
           args: ['--disable-background-networking', '--disable-component-update', '--no-first-run'],
         }, {
@@ -805,13 +866,14 @@ export class BrowserRuntime {
       screencasting: false,
       screencastListenerAttached: false,
       viewport: DEFAULT_BROWSER_VIEWPORT,
+      deviceScaleFactor: DEFAULT_BROWSER_DEVICE_SCALE_FACTOR,
     };
     session.tabs.set(tab.id, tab);
     session.activeTabId = tab.id;
     this.ownerByTarget.set(page.target(), session);
     this.changed();
-    await page.setViewport({ ...DEFAULT_BROWSER_VIEWPORT, deviceScaleFactor: 1 });
     const cdp = await this.cdp(tab);
+    await this.applyViewport(tab, DEFAULT_BROWSER_VIEWPORT, DEFAULT_BROWSER_DEVICE_SCALE_FACTOR, cdp);
     const rememberMainFrame = (frameId: string) => {
       this.ownerByFrameId.set(frameId, { sessionId: session.id, tabId: tab.id });
     };
@@ -898,6 +960,137 @@ export class BrowserRuntime {
     }));
   }
 
+  private async applyViewport(
+    tab: Tab,
+    viewport: BrowserViewportSize,
+    deviceScaleFactor: number,
+    cdp: CDPSession,
+  ): Promise<void> {
+    await tab.page.setViewport({ ...viewport, deviceScaleFactor });
+    // Puppeteer's viewport emulation updates CSS metrics and DPR, but
+    // Page.startScreencast still emits CSS-sized frames. A viewport scale
+    // requests the physical backing surface while preserving CSS input space.
+    await cdp.send('Emulation.setDeviceMetricsOverride', {
+      width: viewport.width,
+      height: viewport.height,
+      deviceScaleFactor,
+      mobile: false,
+      viewport: {
+        x: 0,
+        y: 0,
+        width: viewport.width,
+        height: viewport.height,
+        scale: deviceScaleFactor,
+      },
+    });
+  }
+
+  private async readClipboardSelection(tab: Tab): Promise<ClipboardSelection> {
+    return tab.page.evaluate(() => {
+      const nodePath = (node: Node | null): string => {
+        const parts: number[] = [];
+        let current = node;
+        while (current && current !== document) {
+          const parent = current.parentNode;
+          if (!parent) break;
+          parts.push(Array.prototype.indexOf.call(parent.childNodes, current));
+          current = parent;
+        }
+        return parts.reverse().join('.');
+      };
+      const active = document.activeElement;
+      if (active instanceof HTMLInputElement && active.type === 'password') {
+        return { text: '', editable: false, selectionId: 'none' };
+      }
+      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+        const start = active.selectionStart;
+        const end = active.selectionEnd;
+        if (start !== null && end !== null && start !== end) {
+          return {
+            text: active.value.slice(start, end),
+            editable: !active.readOnly && !active.disabled,
+            selectionId: `control:${nodePath(active)}:${start}:${end}`,
+          };
+        }
+        return { text: '', editable: false, selectionId: 'none' };
+      }
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) {
+        return { text: '', editable: false, selectionId: 'none' };
+      }
+      const anchor = selection.anchorNode;
+      const anchorElement = anchor?.nodeType === Node.ELEMENT_NODE
+        ? anchor as Element
+        : anchor?.parentElement;
+      const editable = Boolean(
+        (active instanceof HTMLElement && active.isContentEditable)
+        || anchorElement?.closest('[contenteditable="true"],[contenteditable="plaintext-only"]'),
+      );
+      return {
+        text: selection.toString(),
+        editable,
+        selectionId: `range:${nodePath(selection.anchorNode)}:${selection.anchorOffset}:${nodePath(selection.focusNode)}:${selection.focusOffset}`,
+      };
+    });
+  }
+
+  private async deleteClipboardSelection(tab: Tab, expectedText: string, expectedSelectionId: string): Promise<boolean> {
+    return tab.page.evaluate(({ expectedText: text, expectedSelectionId: selectionId }) => {
+      const nodePath = (node: Node | null): string => {
+        const parts: number[] = [];
+        let current = node;
+        while (current && current !== document) {
+          const parent = current.parentNode;
+          if (!parent) break;
+          parts.push(Array.prototype.indexOf.call(parent.childNodes, current));
+          current = parent;
+        }
+        return parts.reverse().join('.');
+      };
+      const active = document.activeElement;
+      if (active instanceof HTMLInputElement && active.type === 'password') return false;
+      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+        const start = active.selectionStart;
+        const end = active.selectionEnd;
+        if (
+          start !== null
+          && end !== null
+          && start !== end
+          && !active.readOnly
+          && !active.disabled
+          && active.value.slice(start, end) === text
+          && `control:${nodePath(active)}:${start}:${end}` === selectionId
+        ) {
+          active.setRangeText('', start, end, 'start');
+          active.dispatchEvent(new InputEvent('input', {
+            bubbles: true,
+            inputType: 'deleteByCut',
+            data: null,
+          }));
+          return true;
+        }
+        return false;
+      }
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0 || selection.toString() !== text) return false;
+      const anchor = selection.anchorNode;
+      const anchorElement = anchor?.nodeType === Node.ELEMENT_NODE
+        ? anchor as Element
+        : anchor?.parentElement;
+      if (!(
+        (active instanceof HTMLElement && active.isContentEditable)
+        || anchorElement?.closest('[contenteditable="true"],[contenteditable="plaintext-only"]')
+      )) return false;
+      const currentSelectionId = `range:${nodePath(selection.anchorNode)}:${selection.anchorOffset}:${nodePath(selection.focusNode)}:${selection.focusOffset}`;
+      if (currentSelectionId !== selectionId) return false;
+      selection.deleteFromDocument();
+      const editableElement = anchorElement?.closest('[contenteditable="true"],[contenteditable="plaintext-only"]')
+        ?? (active instanceof HTMLElement && active.isContentEditable ? active : null);
+      editableElement?.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'deleteByCut' }));
+      return true;
+    }, { expectedText, expectedSelectionId });
+  }
+
   private async cdp(tab: Tab): Promise<CDPSession> {
     if (!tab.cdp) tab.cdp = await tab.page.createCDPSession();
     return tab.cdp;
@@ -927,12 +1120,30 @@ export class BrowserRuntime {
           tabId: tab.id,
           mimeType: 'image/jpeg',
           data: event.data,
-          metadata: event.metadata as unknown as Record<string, unknown>,
+          // CDP's deviceWidth/deviceHeight can describe physical pixels after
+          // device emulation. Keep the public frame contract in CSS pixels so
+          // input coordinates remain in the same space as window.innerWidth.
+          metadata: {
+            ...object(event.metadata),
+            deviceWidth: tab.viewport.width,
+            deviceHeight: tab.viewport.height,
+            cssWidth: tab.viewport.width,
+            cssHeight: tab.viewport.height,
+            deviceScaleFactor: tab.deviceScaleFactor,
+          },
         }, session.id);
       });
     }
+    const maxWidth = Math.min(
+      MAX_BROWSER_FRAME_WIDTH,
+      Math.max(1, Math.round(tab.viewport.width * tab.deviceScaleFactor)),
+    );
+    const maxHeight = Math.min(
+      MAX_BROWSER_FRAME_HEIGHT,
+      Math.max(1, Math.round(tab.viewport.height * tab.deviceScaleFactor)),
+    );
     await cdp.send('Page.startScreencast', {
-      format: 'jpeg', quality: 70, maxWidth: 1440, maxHeight: 900, everyNthFrame: 1,
+      format: 'jpeg', quality: 80, maxWidth, maxHeight, everyNthFrame: 1,
     });
   }
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -120,7 +120,7 @@ async function sessionFrame(provider: LLMProvider, providerSessionId: string): P
     sessionId: row.session_id,
     provider: row.provider,
     session: { id: row.session_id, summary: row.custom_name || '', messageCount: 0, lastActivity: row.updated_at ?? row.created_at ?? new Date().toISOString() },
-    project: project ? { projectId: project.project_id, path: project.project_path, fullPath: project.project_path, displayName, isStarred: Boolean(project.isStarred), origin: project.origin } : null,
+    project: project ? { projectId: project.project_id, path: project.project_path, fullPath: project.project_path, displayName, isStarred: Boolean(project.isStarred), isArchived: Boolean(project.isArchived), origin: project.origin } : null,
     timestamp: new Date().toISOString(),
   });
 }

--- a/server/modules/websocket/services/chat-run-registry.service.ts
+++ b/server/modules/websocket/services/chat-run-registry.service.ts
@@ -123,6 +123,7 @@ async function publishSessionUpsert(sessionId: string): Promise<void> {
       fullPath: project.project_path,
       displayName,
       isStarred: Boolean(project.isStarred),
+      isArchived: Boolean(project.isArchived),
       origin: project.origin,
     },
     timestamp: new Date().toISOString(),

--- a/server/modules/websocket/tests/chat-run-registry.test.ts
+++ b/server/modules/websocket/tests/chat-run-registry.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, test } from 'node:test';
 
-import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import { closeConnection, initializeDatabase, projectsDb, sessionsDb } from '@/modules/database/index.js';
 import { chatRunRegistry } from '@/modules/websocket/services/chat-run-registry.service.js';
 import { connectedClients } from '@/modules/websocket/services/websocket-state.service.js';
 
@@ -121,6 +121,23 @@ describe('chat run event protocol', () => {
       assert.deepEqual(framesOf(socket, 'session_upserted').map(({ sessionId, providerSessionId }) => ({ sessionId, providerSessionId })), [
         { sessionId: 'mapping', providerSessionId: 'native-7' },
       ]);
+    });
+  });
+
+  test('publishes archived project state without suppressing the upsert', async () => {
+    await openDatabase(async () => {
+      const { run, socket } = createRun('archived-project');
+      connectedClients.add(socket as never);
+      projectsDb.updateProjectIsArchived('/workspace/demo', true);
+
+      run.writer.send({ kind: 'session_created', provider: 'gjc', sessionId: 'native-archived', newSessionId: 'native-archived' });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const frames = framesOf(socket, 'session_upserted');
+      assert.equal(frames.length, 1);
+      const archivedProject = frames[0]?.project as { isArchived?: unknown } | null | undefined;
+      assert.equal(typeof archivedProject?.isArchived, 'boolean');
+      assert.equal(archivedProject?.isArchived, true);
     });
   });
 

--- a/src/components/workspace/view/BrowserPanel.dom.bun.test.tsx
+++ b/src/components/workspace/view/BrowserPanel.dom.bun.test.tsx
@@ -14,7 +14,13 @@ const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
 const originalBounds = HTMLElement.prototype.getBoundingClientRect;
 const originalResizeObserver = globalThis.ResizeObserver;
+const originalDevicePixelRatio = window.devicePixelRatio;
+const originalClipboard = navigator.clipboard;
+const originalClipboardItem = globalThis.ClipboardItem;
 const sockets: TestSocket[] = [];
+class TestClipboardItem {
+  constructor(readonly data: Record<string, unknown>) {}
+}
 class TestSocket {
   binaryType = '';
   onopen: (() => void) | null = null;
@@ -56,6 +62,9 @@ afterEach(() => {
   URL.revokeObjectURL = originalRevokeObjectURL;
   HTMLElement.prototype.getBoundingClientRect = originalBounds;
   globalThis.ResizeObserver = originalResizeObserver;
+  Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: originalDevicePixelRatio });
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
+  Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: originalClipboardItem });
   sockets.length = 0;
 });
 
@@ -192,6 +201,228 @@ test('a new connection resends the viewport even for the same tab and size', asy
   inputs.length = 0;
   act(() => { sockets[1].state('a', 'Same tab'); sockets[1].onopen?.(); });
   await waitFor(() => assert.deepEqual(inputs, [{ kind: 'viewport', width: 400, height: 300 }]));
+});
+
+test('viewport sync sends a bounded device scale factor while keeping CSS dimensions', async () => {
+  const { inputs, capture } = viewportHarness();
+  Object.defineProperty(window, 'devicePixelRatio', { configurable: true, value: 2.5 });
+  installFetch(capture);
+  render(createElement(BrowserPanel, { sessionId: 'a' }));
+  await screen.findByLabelText('Web address');
+  act(() => sockets[0].state('a', 'Retina page'));
+  await waitFor(() => assert.deepEqual(inputs, [{
+    kind: 'viewport',
+    width: 400,
+    height: 300,
+    deviceScaleFactor: 2,
+  }]));
+});
+
+test('Ctrl and Cmd clipboard shortcuts bridge text only from the focused browser surface', async () => {
+  const inputs: Record<string, unknown>[] = [];
+  let resolveSelection!: (response: Response) => void;
+  const localText = 'paste from host';
+  const writes: ClipboardItem[] = [];
+  Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: TestClipboardItem });
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      readText: async () => localText,
+      write: async (items: ClipboardItem[]) => { writes.push(...items); },
+    },
+  });
+  installFetch((url, init) => {
+    if (!url.endsWith('/input')) return undefined;
+    const input = (JSON.parse(String(init?.body)) as { input: Record<string, unknown> }).input;
+    inputs.push(input);
+    if (input.kind === 'clipboard' && input.event === 'read') {
+      return new Promise((resolve) => { resolveSelection = resolve; });
+    }
+    return Promise.resolve(new Response(JSON.stringify(
+      input.event === 'delete' ? { accepted: true, deleted: true } : { accepted: true },
+    )));
+  });
+  render(createElement(BrowserPanel, { sessionId: 'a' }));
+  await screen.findByLabelText('Web address');
+  act(() => sockets[0].state('a', 'Clipboard page'));
+  const surface = document.querySelector('[tabindex="0"]') as HTMLElement;
+  const address = screen.getByLabelText('Web address');
+
+  fireEvent.keyDown(surface, { key: 'c', code: 'KeyC', ctrlKey: true });
+  assert.equal(writes.length, 1, 'ClipboardItem write starts during the keyboard activation');
+  assert.deepEqual(inputs[0], { kind: 'clipboard', event: 'read', tabId: 'tab' });
+  await act(async () => resolveSelection(new Response(JSON.stringify({
+    accepted: true,
+    text: 'remote copy',
+    editable: true,
+    selectionId: 'selection-1',
+  }))));
+  fireEvent.keyUp(surface, { key: 'Control', code: 'ControlLeft' });
+  assert.equal(screen.queryByRole('alert'), null);
+
+  fireEvent.keyDown(address, { key: 'c', code: 'KeyC', ctrlKey: true });
+  assert.equal(inputs.length, 1, 'address input shortcuts stay local');
+
+  fireEvent.keyDown(surface, { key: 'x', code: 'KeyX', metaKey: true });
+  await act(async () => resolveSelection(new Response(JSON.stringify({
+    accepted: true,
+    text: 'remote cut',
+    editable: true,
+    selectionId: 'selection-2',
+  }))));
+  await waitFor(() => assert.deepEqual(inputs.at(-1), {
+    kind: 'clipboard',
+    event: 'delete',
+    tabId: 'tab',
+    text: 'remote cut',
+    selectionId: 'selection-2',
+  }));
+  fireEvent.keyUp(surface, { key: 'Meta', code: 'MetaLeft' });
+
+  fireEvent.keyDown(surface, { key: 'v', code: 'KeyV', ctrlKey: true });
+  await waitFor(() => assert.deepEqual(inputs.at(-1), {
+    kind: 'clipboard',
+    event: 'paste',
+    tabId: 'tab',
+    text: 'paste from host',
+  }));
+  fireEvent.keyUp(surface, { key: 'Control', code: 'ControlLeft' });
+});
+
+test('mixed clipboard and editing shortcuts keep the remote modifier lifecycle balanced', async () => {
+  const inputs: Record<string, unknown>[] = [];
+  Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: TestClipboardItem });
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { write: async () => {}, readText: async () => '' },
+  });
+  installFetch((url, init) => {
+    if (!url.endsWith('/input')) return undefined;
+    const input = (JSON.parse(String(init?.body)) as { input: Record<string, unknown> }).input;
+    inputs.push(input);
+    if (input.kind === 'clipboard' && input.event === 'read') {
+      return Promise.resolve(new Response(JSON.stringify({
+        accepted: true,
+        text: 'selected',
+        editable: true,
+        selectionId: 'selection-1',
+      })));
+    }
+    return Promise.resolve(new Response('{"accepted":true}'));
+  });
+  render(createElement(BrowserPanel, { sessionId: 'a' }));
+  await screen.findByLabelText('Web address');
+  act(() => sockets[0].state('a', 'Modifier lifecycle'));
+  const surface = document.querySelector('[tabindex="0"]') as HTMLElement;
+  const keyInputs = () => inputs.filter((input) => input.kind === 'key');
+
+  fireEvent.keyDown(surface, { key: 'Meta', code: 'MetaLeft', metaKey: true });
+  fireEvent.keyDown(surface, { key: 'a', code: 'KeyA', metaKey: true });
+  fireEvent.keyUp(surface, { key: 'a', code: 'KeyA', metaKey: true });
+  fireEvent.keyDown(surface, { key: 'ㅊ', code: 'KeyC', metaKey: true });
+  fireEvent.keyUp(surface, { key: 'ㅊ', code: 'KeyC', metaKey: true });
+  fireEvent.keyUp(surface, { key: 'Meta', code: 'MetaLeft' });
+  await waitFor(() => assert.deepEqual(keyInputs(), [
+    { kind: 'key', event: 'down', key: 'Meta', code: 'MetaLeft', modifiers: 4 },
+    { kind: 'key', event: 'down', key: 'a', code: 'KeyA', modifiers: 4 },
+    { kind: 'key', event: 'up', key: 'a', code: 'KeyA', modifiers: 4 },
+    { kind: 'key', event: 'up', key: 'Meta', code: 'MetaLeft', modifiers: 4 },
+  ]));
+
+  inputs.length = 0;
+  fireEvent.keyDown(surface, { key: 'Meta', code: 'MetaLeft', metaKey: true });
+  fireEvent.keyDown(surface, { key: 'ㅊ', code: 'KeyC', metaKey: true });
+  fireEvent.keyUp(surface, { key: 'ㅊ', code: 'KeyC', metaKey: true });
+  fireEvent.keyDown(surface, { key: 'a', code: 'KeyA', metaKey: true });
+  fireEvent.keyUp(surface, { key: 'a', code: 'KeyA', metaKey: true });
+  fireEvent.keyUp(surface, { key: 'Meta', code: 'MetaLeft' });
+  await waitFor(() => assert.deepEqual(keyInputs(), [
+    { kind: 'key', event: 'down', key: 'Meta', code: 'MetaLeft', modifiers: 4 },
+    { kind: 'key', event: 'down', key: 'a', code: 'KeyA', modifiers: 4 },
+    { kind: 'key', event: 'up', key: 'a', code: 'KeyA', modifiers: 4 },
+    { kind: 'key', event: 'up', key: 'Meta', code: 'MetaLeft', modifiers: 4 },
+  ]));
+  assert.equal(inputs.some((input) => input.kind === 'key' && input.key === 'ㅊ'), false);
+});
+
+test('an empty remote selection rejects the pending clipboard item without cutting or replacing local text', async () => {
+  const inputs: Record<string, unknown>[] = [];
+  let resolveSelection!: (response: Response) => void;
+  let itemTextPromise!: Promise<Blob>;
+  let writeStarted = false;
+  let localClipboard = 'existing local clipboard';
+  Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: TestClipboardItem });
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      readText: async () => localClipboard,
+      write: async (items: TestClipboardItem[]) => {
+        writeStarted = true;
+        itemTextPromise = items[0].data['text/plain'] as Promise<Blob>;
+        const blob = await itemTextPromise;
+        localClipboard = await blob.text();
+      },
+    },
+  });
+  installFetch((url, init) => {
+    if (!url.endsWith('/input')) return undefined;
+    const input = (JSON.parse(String(init?.body)) as { input: Record<string, unknown> }).input;
+    inputs.push(input);
+    if (input.kind === 'clipboard' && input.event === 'read') {
+      return new Promise((resolve) => { resolveSelection = resolve; });
+    }
+    return Promise.resolve(new Response('{"accepted":true}'));
+  });
+  render(createElement(BrowserPanel, { sessionId: 'a' }));
+  await screen.findByLabelText('Web address');
+  act(() => sockets[0].state('a', 'Empty selection'));
+  const surface = document.querySelector('[tabindex="0"]') as HTMLElement;
+  fireEvent.keyDown(surface, { key: 'x', code: 'KeyX', ctrlKey: true });
+  assert.equal(writeStarted, true, 'the clipboard write starts during the transient keyboard activation');
+  await act(async () => resolveSelection(new Response(JSON.stringify({
+    accepted: true,
+    text: '',
+    editable: true,
+    selectionId: 'selection-empty',
+  }))));
+  await assert.rejects(itemTextPromise, /browser_clipboard_no_selection/);
+  await waitFor(() => assert.equal(inputs.some((input) => input.event === 'delete'), false));
+  assert.equal(localClipboard, 'existing local clipboard');
+  assert.equal(screen.queryByRole('alert'), null, 'the expected no-selection result is not surfaced as an error');
+});
+
+test('failed local clipboard writes leave the remote selection untouched and show the error', async () => {
+  const inputs: Record<string, unknown>[] = [];
+  let resolveSelection!: (response: Response) => void;
+  Object.defineProperty(globalThis, 'ClipboardItem', { configurable: true, value: TestClipboardItem });
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      write: async () => { throw new Error('Clipboard permission denied.'); },
+      readText: async () => '',
+    },
+  });
+  installFetch((url, init) => {
+    if (!url.endsWith('/input')) return undefined;
+    const input = (JSON.parse(String(init?.body)) as { input: Record<string, unknown> }).input;
+    inputs.push(input);
+    return input.event === 'read'
+      ? new Promise((resolve) => { resolveSelection = resolve; })
+      : Promise.resolve(new Response('{"accepted":true}'));
+  });
+  render(createElement(BrowserPanel, { sessionId: 'a' }));
+  await screen.findByLabelText('Web address');
+  act(() => sockets[0].state('a', 'Clipboard failure'));
+  const surface = document.querySelector('[tabindex="0"]') as HTMLElement;
+  fireEvent.keyDown(surface, { key: 'x', code: 'KeyX', ctrlKey: true });
+  await act(async () => resolveSelection(new Response(JSON.stringify({
+    accepted: true,
+    text: 'must remain selected',
+    editable: true,
+    selectionId: 'selection-1',
+  }))));
+  await waitFor(() => assert.match(screen.getByRole('alert').textContent ?? '', /permission denied/i));
+  assert.equal(inputs.some((input) => input.event === 'delete'), false);
 });
 
 test('click mapping follows the loaded frame, not the pending viewport resize or next frame', async () => {

--- a/src/components/workspace/view/BrowserPanel.tsx
+++ b/src/components/workspace/view/BrowserPanel.tsx
@@ -37,7 +37,80 @@ type BrowserPanelProps = {
   onNavigationHandled?: () => void;
 };
 
+type BrowserInputResponse = {
+  accepted?: boolean;
+  text?: string;
+  editable?: boolean;
+  selectionId?: string;
+  deleted?: boolean;
+};
+
+type ClipboardShortcut = {
+  key: 'c' | 'x' | 'v';
+  modifier: 'Control' | 'Meta';
+};
+
+type PendingModifier = {
+  key: 'Control' | 'Meta';
+  code: string;
+  flushed: boolean;
+};
+
 const COMMON_LOCAL_URLS = ['http://localhost:5173', 'http://localhost:3000', 'http://localhost:4173', 'http://localhost:8000'];
+const DEFAULT_BROWSER_DEVICE_SCALE_FACTOR = 1;
+const MAX_BROWSER_DEVICE_SCALE_FACTOR = 2;
+
+function browserDeviceScaleFactor(): number {
+  const value = typeof window === 'undefined' ? DEFAULT_BROWSER_DEVICE_SCALE_FACTOR : window.devicePixelRatio;
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_BROWSER_DEVICE_SCALE_FACTOR;
+  return Math.min(
+    Math.max(Math.round(value * 100) / 100, DEFAULT_BROWSER_DEVICE_SCALE_FACTOR),
+    MAX_BROWSER_DEVICE_SCALE_FACTOR,
+  );
+}
+
+function clipboardShortcutKey(event: Pick<KeyboardEvent<HTMLDivElement>, 'code' | 'key'>): ClipboardShortcut['key'] | null {
+  if (event.code === 'KeyC') return 'c';
+  if (event.code === 'KeyX') return 'x';
+  if (event.code === 'KeyV') return 'v';
+  const key = event.key.toLowerCase();
+  return key === 'c' || key === 'x' || key === 'v' ? key : null;
+}
+
+function modifierBit(key: PendingModifier['key']): number {
+  return key === 'Control' ? 2 : 4;
+}
+
+async function readLocalClipboard(): Promise<string> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
+    throw new Error('Clipboard read is unavailable in this browser.');
+  }
+  return navigator.clipboard.readText();
+}
+
+const NO_BROWSER_SELECTION = 'browser_clipboard_no_selection';
+
+function isNoBrowserSelectionError(error: unknown): boolean {
+  return error instanceof Error && error.message === NO_BROWSER_SELECTION;
+}
+
+function writeRemoteClipboard(selectionPromise: Promise<BrowserInputResponse>): Promise<void> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
+    return Promise.reject(new Error('Clipboard write is unavailable in this browser.'));
+  }
+  const textPromise = selectionPromise.then((selection) => {
+    if (selection.text === '') throw new Error(NO_BROWSER_SELECTION);
+    if (typeof selection.text !== 'string') throw new Error('The browser returned no clipboard text.');
+    return new Blob([selection.text], { type: 'text/plain' });
+  });
+  const item = new ClipboardItem({ 'text/plain': textPromise });
+  // Start the write synchronously for transient user activation, while also
+  // awaiting the representation promise so a missing selection cannot commit
+  // (or become an unhandled rejection in a host clipboard shim).
+  const writePromise = navigator.clipboard.write([item]);
+  void writePromise.catch(() => {});
+  return textPromise.then(() => writePromise).then(() => undefined);
+}
 
 async function jsonRequest<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, {
@@ -71,9 +144,13 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
   const frameRef = useRef<HTMLImageElement | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const frameViewportRef = useRef<BrowserViewportSize>(DEFAULT_BROWSER_VIEWPORT);
-  const sentViewportRef = useRef<BrowserViewportSize | null>(null);
+  const sentViewportRef = useRef<(BrowserViewportSize & { deviceScaleFactor: number }) | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
   const pointerFrameRef = useRef<number | null>(null);
+  const clipboardShortcutRef = useRef<ClipboardShortcut | null>(null);
+  const pendingModifierRef = useRef<PendingModifier | null>(null);
+  const clipboardGenerationRef = useRef(0);
+  const activeTabIdRef = useRef<string | null>(null);
   const acceptFramesRef = useRef(false);
   const handledNavigationRef = useRef<number | null>(null);
 
@@ -206,12 +283,17 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
           sessionId?: string;
           tabId?: string;
           mimeType?: string;
-          metadata?: { deviceWidth?: unknown; deviceHeight?: unknown };
+          metadata?: {
+            cssWidth?: unknown;
+            cssHeight?: unknown;
+            deviceWidth?: unknown;
+            deviceHeight?: unknown;
+          };
         };
         if (header.type !== 'frame' || header.sessionId !== sessionId) return;
         const frameViewport = normalizeBrowserViewport(
-          header.metadata?.deviceWidth,
-          header.metadata?.deviceHeight,
+          header.metadata?.cssWidth ?? header.metadata?.deviceWidth,
+          header.metadata?.cssHeight ?? header.metadata?.deviceHeight,
         );
         const nextUrl = URL.createObjectURL(new Blob([packet.slice(4 + headerLength)], { type: header.mimeType ?? 'image/jpeg' }));
         replaceFrameUrl(nextUrl, frameViewport ?? DEFAULT_BROWSER_VIEWPORT, header.tabId);
@@ -272,15 +354,66 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
     }
   }, [sessionId, t]);
 
-  const sendInput = useCallback((input: Record<string, unknown>) => {
-    void jsonRequest(`/api/browser/${encodeURIComponent(sessionId)}/input`, {
+  const requestInput = useCallback((input: Record<string, unknown>) => jsonRequest<BrowserInputResponse>(
+    `/api/browser/${encodeURIComponent(sessionId)}/input`,
+    {
       method: 'POST',
       body: JSON.stringify({ input }),
-    }).catch((nextError) => setError(nextError instanceof Error ? nextError.message : t('workspace.browser.error')));
-  }, [sessionId, t]);
+    },
+  ), [sessionId]);
+
+  const sendInput = useCallback((input: Record<string, unknown>) => {
+    void requestInput(input).catch((nextError) => {
+      setError(nextError instanceof Error ? nextError.message : t('workspace.browser.error'));
+    });
+  }, [requestInput, t]);
 
   const activeTabId = activeTab?.id ?? null;
+  activeTabIdRef.current = activeTabId;
   const previewReady = Boolean(status?.supported && (status.browser.installed || state));
+  useEffect(() => {
+    clipboardGenerationRef.current += 1;
+    return () => { clipboardGenerationRef.current += 1; };
+  }, [sessionId]);
+
+  const clipboardAction = useCallback(async (action: ClipboardShortcut['key']) => {
+    if (!activeTabId) return;
+    const tabId = activeTabId;
+    const generation = clipboardGenerationRef.current;
+    const targetStillFocused = () => generation === clipboardGenerationRef.current && tabId === activeTabIdRef.current;
+    try {
+      if (action === 'v') {
+        const text = await readLocalClipboard();
+        if (text && targetStillFocused()) await requestInput({ kind: 'clipboard', event: 'paste', tabId, text });
+        return;
+      }
+      const selectionPromise = requestInput({
+        kind: 'clipboard',
+        event: 'read',
+        tabId,
+      });
+      await writeRemoteClipboard(selectionPromise);
+      const selection = await selectionPromise;
+      if (!selection.text) return;
+      if (action === 'x' && selection.editable && selection.selectionId && targetStillFocused()) {
+        const deletion = await requestInput({
+          kind: 'clipboard',
+          event: 'delete',
+          tabId,
+          text: selection.text,
+          selectionId: selection.selectionId,
+        });
+        if (!deletion.deleted) {
+          throw new Error('The browser selection changed before cut completed.');
+        }
+      }
+    } catch (nextError) {
+      if (!isNoBrowserSelectionError(nextError)) {
+        setError(nextError instanceof Error ? nextError.message : t('workspace.browser.error'));
+      }
+    }
+  }, [activeTabId, requestInput, t]);
+
   useEffect(() => {
     const surface = surfaceRef.current;
     if (!surface || !activeTabId) return undefined;
@@ -291,17 +424,26 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
       timer = setTimeout(() => {
         const bounds = surface.getBoundingClientRect();
         const viewport = normalizeBrowserViewport(bounds.width, bounds.height);
+        const deviceScaleFactor = browserDeviceScaleFactor();
         const previous = sentViewportRef.current;
-        if (!viewport || (previous?.width === viewport.width && previous.height === viewport.height)) return;
-        sentViewportRef.current = viewport;
-        sendInput({ kind: 'viewport', ...viewport });
+        if (!viewport || (previous?.width === viewport.width
+          && previous.height === viewport.height
+          && previous.deviceScaleFactor === deviceScaleFactor)) return;
+        sentViewportRef.current = { ...viewport, deviceScaleFactor };
+        sendInput({
+          kind: 'viewport',
+          ...viewport,
+          ...(deviceScaleFactor === DEFAULT_BROWSER_DEVICE_SCALE_FACTOR ? {} : { deviceScaleFactor }),
+        });
       }, 80);
     };
     syncViewport();
     const observer = new ResizeObserver(syncViewport);
     observer.observe(surface);
+    window.addEventListener('resize', syncViewport);
     return () => {
       observer.disconnect();
+      window.removeEventListener('resize', syncViewport);
       if (timer) clearTimeout(timer);
     };
   }, [activeTabId, connection, previewReady, sendInput]);
@@ -331,7 +473,38 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.nativeEvent.isComposing) return;
+    if (event.nativeEvent.isComposing || event.target !== event.currentTarget) return;
+    if (event.key === 'Control' || event.key === 'Meta') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!event.repeat && pendingModifierRef.current?.key !== event.key) {
+        pendingModifierRef.current = { key: event.key, code: event.code, flushed: false };
+      }
+      return;
+    }
+    const key = clipboardShortcutKey(event);
+    const modifier = event.metaKey ? 'Meta' : event.ctrlKey ? 'Control' : null;
+    if (modifier && !event.altKey && !event.shiftKey && key) {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.repeat) return;
+      clipboardShortcutRef.current = { key, modifier };
+      void clipboardAction(key);
+      return;
+    }
+    const pendingModifier = pendingModifierRef.current;
+    if (pendingModifier) {
+      if (!pendingModifier.flushed) {
+        pendingModifier.flushed = true;
+        sendInput({
+          kind: 'key',
+          event: 'down',
+          key: pendingModifier.key,
+          code: pendingModifier.code,
+          modifiers: modifierBit(pendingModifier.key),
+        });
+      }
+    }
     if (event.metaKey || event.ctrlKey || event.altKey || event.key.length !== 1) {
       event.preventDefault();
       sendInput({ kind: 'key', event: 'down', key: event.key, code: event.code, modifiers: (event.altKey ? 1 : 0) | (event.ctrlKey ? 2 : 0) | (event.metaKey ? 4 : 0) | (event.shiftKey ? 8 : 0) });
@@ -342,6 +515,35 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
   };
 
   const handleKeyUp = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) return;
+    const clipboardShortcut = clipboardShortcutRef.current;
+    const releasedShortcutKey = clipboardShortcutKey(event);
+    if (clipboardShortcut && releasedShortcutKey === clipboardShortcut.key) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (event.key === 'Control' || event.key === 'Meta') {
+      const pendingModifier = pendingModifierRef.current?.key === event.key
+        ? pendingModifierRef.current
+        : null;
+      const clipboardModifier = clipboardShortcut?.modifier === event.key;
+      if (!pendingModifier && !clipboardModifier) return;
+      event.preventDefault();
+      event.stopPropagation();
+      pendingModifierRef.current = null;
+      clipboardShortcutRef.current = null;
+      if (pendingModifier?.flushed) {
+        sendInput({
+          kind: 'key',
+          event: 'up',
+          key: pendingModifier.key,
+          code: pendingModifier.code,
+          modifiers: modifierBit(pendingModifier.key),
+        });
+      }
+      return;
+    }
     if (!event.metaKey && !event.ctrlKey && !event.altKey && event.key.length === 1) return;
     event.preventDefault();
     sendInput({
@@ -455,6 +657,10 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
+        onBlur={() => {
+          clipboardShortcutRef.current = null;
+          pendingModifierRef.current = null;
+        }}
         className="relative flex min-h-0 min-w-0 flex-1 items-center justify-center overflow-hidden bg-background outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
       >
         {frameUrl ? (
@@ -526,7 +732,7 @@ function BrowserSession({ sessionId, navigationRequest, onNavigationHandled }: B
           </div>
         )}
       </div>
-      {error && <div className="max-h-24 shrink-0 overflow-auto border-t border-destructive/30 bg-destructive/10 px-2.5 py-1.5 text-xs break-words text-destructive">{error}</div>}
+      {error && <div role="alert" className="max-h-24 shrink-0 overflow-auto border-t border-destructive/30 bg-destructive/10 px-2.5 py-1.5 text-xs break-words text-destructive">{error}</div>}
       {status?.cua && (
         <div className="flex shrink-0 items-center justify-between border-t border-border/60 px-2.5 py-1 text-[10px] text-muted-foreground">
           <span>{t('workspace.browser.cua')}</span>

--- a/src/hooks/useProjectsState.query.dom.bun.test.tsx
+++ b/src/hooks/useProjectsState.query.dom.bun.test.tsx
@@ -168,6 +168,97 @@ test('session upserts write directly to the project cache', async () => {
   }
 });
 
+test('archived project upserts leave the active cache alone while new projects are inserted', async () => {
+  const fetch = installFetch([{ body: [project()] }]);
+  try {
+    const harness = renderHarness();
+    await waitFor(() => assert.equal(harness.getState().projects.length, 1));
+
+    act(() => harness.emit({
+      kind: 'session_upserted',
+      sessionId: 'archived-session',
+      provider: 'gjc',
+      session: { id: 'archived-session', summary: 'Archived update' },
+      project: {
+        projectId: 'project-archived',
+        path: '/workspace/archived',
+        fullPath: '/workspace/archived',
+        displayName: 'Archived project',
+        isStarred: false,
+        isArchived: true,
+      },
+      timestamp: new Date().toISOString(),
+    } as ServerEvent));
+    assert.deepEqual(harness.getState().projects.map((item) => item.projectId), ['project-1']);
+
+    act(() => harness.emit({
+      kind: 'session_upserted',
+      sessionId: 'new-session',
+      provider: 'gjc',
+      session: { id: 'new-session', summary: 'New project update' },
+      project: {
+        projectId: 'project-new',
+        path: '/workspace/new',
+        fullPath: '/workspace/new',
+        displayName: 'New project',
+        isStarred: false,
+        isArchived: false,
+      },
+      timestamp: new Date().toISOString(),
+    } as ServerEvent));
+    await waitFor(() => assert.deepEqual(harness.getState().projects.map((item) => item.projectId), ['project-1', 'project-new']));
+    assert.deepEqual(harness.getState().projects[1]?.sessions?.map((session) => session.id), ['new-session']);
+  } finally {
+    fetch.restore();
+  }
+});
+
+test('an archived upsert removes a stale cached row without dropping the selected project', async () => {
+  const fetch = installFetch([{ body: [project()] }]);
+  try {
+    const harness = renderHarness();
+    await waitFor(() => assert.equal(harness.getState().projects.length, 1));
+    await waitFor(() => assert.equal(harness.getState().selectedProject?.projectId, 'project-1'));
+
+    act(() => harness.emit({
+      kind: 'session_upserted',
+      sessionId: 'archived-session',
+      provider: 'gjc',
+      session: { id: 'archived-session', summary: 'Archived update' },
+      project: {
+        projectId: 'project-1',
+        path: '/workspace/project',
+        fullPath: '/workspace/project',
+        displayName: 'Project one',
+        isStarred: false,
+        isArchived: true,
+      },
+      timestamp: new Date().toISOString(),
+    } as ServerEvent));
+
+    await waitFor(() => assert.equal(harness.getState().projects.length, 0));
+    assert.equal(harness.getState().selectedProject?.projectId, 'project-1');
+    assert.equal(harness.getState().selectedProject?.isArchived, true);
+    assert.equal(harness.getState().selectedProject?.sessions?.[0]?.id, 'archived-session');
+
+    const archivedProject = harness.getState().selectedProject;
+    assert.ok(archivedProject);
+    act(() => {
+      harness.getState().registerOptimisticSession({
+        sessionId: 'archived-optimistic',
+        provider: 'gjc',
+        project: archivedProject,
+        summary: 'Archived optimistic update',
+      });
+    });
+    assert.equal(harness.getState().projects.length, 0);
+    assert.equal(harness.getState().selectedProject?.isArchived, true);
+    assert.equal(harness.getState().selectedSession?.id, 'archived-optimistic');
+  } finally {
+    fetch.restore();
+  }
+});
+
 test('an upsert carrying an origin promotes the cached project so the sidebar can show it', async () => {
   // The indexer had only discovered the repo ('auto', hidden); a workspace
   // descend registered it as explicit on the server and the session landed.

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -14,7 +14,7 @@ import type { SessionActivityMap } from './useSessionProtection';
 export { projectsHaveChanges, readProjectsResponse } from './useProjectsQuery';
 
 type UseProjectsStateArgs = { sessionId?: string | null; navigate: NavigateFunction; subscribe: (listener: (event: ServerEvent) => void) => () => void; isMobile: boolean; activeSessions: SessionActivityMap };
-type SessionUpsert = ServerEvent & { sessionId: string; providerSessionId?: string | null; provider: LLMProvider; session: ProjectSession; project: { projectId: string; path: string; fullPath: string; displayName: string; isStarred: boolean; origin?: Project['origin'] } | null };
+type SessionUpsert = ServerEvent & { sessionId: string; providerSessionId?: string | null; provider: LLMProvider; session: ProjectSession; project: { projectId: string; path: string; fullPath: string; displayName: string; isStarred: boolean; isArchived?: boolean; origin?: Project['origin'] } | null };
 type RegisterOptimisticSessionArgs = { sessionId: string; provider: LLMProvider; project: Project; summary?: string | null };
 type ProjectSessionPage = Pick<Project, 'sessions' | 'sessionMeta'>;
 type FetchProjectsOptions = { showLoadingState?: boolean };
@@ -55,12 +55,16 @@ const aliasesFor = (event: SessionUpsert) => {
 const applySessionUpsert = (project: Project, event: SessionUpsert): Project => {
   const aliases = aliasesFor(event);
   const replacement: ProjectSession = { ...event.session, id: event.sessionId, __provider: event.provider };
+  const eventArchived = event.project?.isArchived;
+  const withArchiveState = typeof eventArchived === 'boolean' && eventArchived !== project.isArchived
+    ? { ...project, isArchived: eventArchived }
+    : project;
   const existing = rowsOf(project);
   const matchingIndex = existing.findIndex((session) => aliases.has(String(session.id)));
   if (matchingIndex < 0) {
     const sessions = [replacement, ...existing];
     const total = Number(project.sessionMeta?.total ?? 0) + 1;
-    return { ...project, sessions, sessionMeta: { ...project.sessionMeta, total, hasMore: sessions.length < total } };
+    return { ...withArchiveState, sessions, sessionMeta: { ...project.sessionMeta, total, hasMore: sessions.length < total } };
   }
 
   let changed = false;
@@ -77,7 +81,7 @@ const applySessionUpsert = (project: Project, event: SessionUpsert): Project => 
     }
     return kept;
   }, []);
-  return changed ? { ...project, sessions } : project;
+  return changed ? { ...withArchiveState, sessions } : withArchiveState;
 };
 
 const pageIntoProject = (project: Project, page: ProjectSessionPage): Project => {
@@ -98,6 +102,11 @@ const updateProjectCache = (projects: Project[], event: SessionUpsert): Project[
   const found = projects.find((project) => projectId
     ? project.projectId === projectId
     : rowsOf(project).some((session) => session.id === event.sessionId));
+  if (event.project?.isArchived === true) {
+    // The active-project query excludes archived rows; discard stale cache
+    // entries while the caller continues updating selected-session state.
+    return found ? projects.filter((project) => project !== found) : projects;
+  }
   if (found) {
     // The database only promotes discovered rows ('auto'/'legacy') to explicit;
     // a later index event must never demote an explicit cached project.
@@ -143,7 +152,7 @@ export function useProjectsState({ sessionId, navigate, subscribe, isMobile, act
     if (!id || !project?.projectId) return;
     const now = new Date().toISOString();
     const session: ProjectSession = { id, summary: summary ?? '', messageCount: 0, createdAt: now, created_at: now, updated_at: now, lastActivity: now, __provider: provider, __projectId: project.projectId };
-    const event: SessionUpsert = { kind: 'session_upserted', sessionId: id, provider, session, project: { projectId: project.projectId, path: project.path || project.fullPath, fullPath: project.fullPath || project.path || '', displayName: project.displayName, isStarred: Boolean(project.isStarred), origin: project.origin }, timestamp: now };
+    const event: SessionUpsert = { kind: 'session_upserted', sessionId: id, provider, session, project: { projectId: project.projectId, path: project.path || project.fullPath, fullPath: project.fullPath || project.path || '', displayName: project.displayName, isStarred: Boolean(project.isStarred), isArchived: Boolean(project.isArchived), origin: project.origin }, timestamp: now };
     client.setQueryData<Project[]>(PROJECTS_QUERY_KEY, (cached) => updateProjectCache(cached ?? [], event));
     setSelectedProject((current) => current?.projectId === project.projectId ? applySessionUpsert(current, event) : current);
     setSelectedSession((current) => current?.id === id ? { ...current, ...session } : session);


### PR DESCRIPTION
## Summary
- Keep archived projects out of the active sidebar cache while preserving live selected-session updates and legitimate new-project insertion.
- Render browser previews at bounded viewer DPR, with physical screencast dimensions and CSS-space pointer coordinates.
- Bridge focused Ctrl/Cmd copy, cut, and paste as plain text using activation-safe ClipboardItem writes; preserve local clipboard on empty selections, reject password copying, and guard delayed cut/tab/selection changes.
- Cover Korean keyboard layouts, mixed modifier shortcuts, readonly fields, reactive input events, and replacement fill behavior.

## Verification
- `npm run verify` passed on the final source changes.
- `npm run test:e2e:browser` passed (3 tests); real Chromium decoded a 2000x1400 frame for a 1000x700 CSS viewport at DPR2 and accepted bottom-right CSS-space input.
- Focused BrowserPanel and project cache DOM suites passed (31 tests).
- `git diff --check` passed.

## Limits
- Plain text only; browser clipboard permission and a secure context are required.
- No signed desktop release, installed-app replacement, or interactive WKWebView clipboard acceptance was performed.