### PR TITLE
docs: sign contributor license agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -96,6 +96,7 @@ Signed-off by: <name> <email> — GitHub @<handle> — YYYY-MM-DD
 
 - Hako (devswha) — project owner; copyright holder, not a licensor to itself.
 - Signed-off by: 이종명 <114718483+lee98www@users.noreply.github.com> — GitHub @lee98www — 2026-09-04
+- Signed-off by: Jun Koo <18099194+snowykr@users.noreply.github.com> — GitHub @snowykr — 2026-09-10
 
 ---
 


### PR DESCRIPTION
I have read and agree to the terms in CLA.md.

This adds my signatory record using my GitHub noreply address, consistent with the existing entry.