### PR TITLE
fix(gjc): support linux-arm64 runtime bootstrap

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -96,6 +96,7 @@ Signed-off by: <name> <email> — GitHub @<handle> — YYYY-MM-DD
 
 - Hako (devswha) — project owner; copyright holder, not a licensor to itself.
 - Signed-off by: 이종명 <114718483+lee98www@users.noreply.github.com> — GitHub @lee98www — 2026-09-04
+- Signed-off by: gimso2x <gimso2x@gmail.com> — GitHub @gimso2x — 2026-09-11
 
 ---
 

--- a/scripts/fetch-bun.mjs
+++ b/scripts/fetch-bun.mjs
@@ -21,6 +21,11 @@ const PLATFORMS = {
     archiveSha256: 'c669e97f6164e1c96e0701748db98dfa77492908cbd8394c7557134a735de381',
     binary: 'bun-darwin-aarch64/bun',
   },
+  'linux-arm64': {
+    archive: 'bun-linux-aarch64.zip',
+    archiveSha256: '4b1a332ee861983eb93bcfe6f770fff94e3e31b2c388bdaea3c8ed35e58eed0e',
+    binary: 'bun-linux-aarch64/bun',
+  },
 };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -91,7 +96,7 @@ async function extractBinary(archivePath, archiveBinaryPath, destinationPath) {
 }
 
 if (!platform) {
-  throw new Error(`Bun ${BUN_VERSION} is only bundled for linux-x64 and darwin-arm64; received ${platformKey}.`);
+  throw new Error(`Bun ${BUN_VERSION} is only bundled for linux-x64, darwin-arm64 and linux-arm64; received ${platformKey}.`);
 }
 
 if (await versionOf(destination) === BUN_VERSION) {

--- a/scripts/fill-runtime-manifest.mjs
+++ b/scripts/fill-runtime-manifest.mjs
@@ -17,7 +17,7 @@ const manifestPath = path.join(rootDir, 'server', 'gjc-runtime-manifest.json');
 const resolverFrom = path.join(rootDir, 'server');
 const argv = process.argv.slice(2);
 const update = argv.includes('--update');
-// Runtime v2 supports Linux x64 and macOS arm64 only; Windows remains intentionally frozen out.
+// Runtime v2 supports Linux x64, Linux arm64 and macOS arm64; Windows remains intentionally frozen out.
 const SUPPORTED_PLATFORMS = new Set(['linux-x64', 'darwin-arm64', 'linux-arm64']);
 
 /**

--- a/scripts/fill-runtime-manifest.mjs
+++ b/scripts/fill-runtime-manifest.mjs
@@ -18,7 +18,7 @@ const resolverFrom = path.join(rootDir, 'server');
 const argv = process.argv.slice(2);
 const update = argv.includes('--update');
 // Runtime v2 supports Linux x64 and macOS arm64 only; Windows remains intentionally frozen out.
-const SUPPORTED_PLATFORMS = new Set(['linux-x64', 'darwin-arm64']);
+const SUPPORTED_PLATFORMS = new Set(['linux-x64', 'darwin-arm64', 'linux-arm64']);
 
 /**
  * Fill the closure for a platform this machine is not.

--- a/server/gjc-runtime-manifest.json
+++ b/server/gjc-runtime-manifest.json
@@ -56,6 +56,30 @@
           "sha256": "7332a76de7195891429bf759c00737aef4f0b158b727c3b81cb920defe867e1f"
         }
       ]
+    },
+    "linux-arm64": {
+      "files": [
+        {
+          "package": "@gajae-code/natives-linux-arm64",
+          "path": "native/pi_natives.linux-arm64.node",
+          "sha256": "c7c3ddb48afeccb9395dc97c50c3557ec879404f8b933df2f459c9aa8f36a3fd"
+        },
+        {
+          "package": "@gajae-code/natives",
+          "path": "native/embedded-addon.js",
+          "sha256": "0ee3be1ce9f174e0c3905bfda78f665d6c177b0e953303b35ff5c5b7735552db"
+        },
+        {
+          "package": "@gajae-code/natives",
+          "path": "native/index.js",
+          "sha256": "516e4316618c77843058bc7f1c1c723ce8d24aa0e1c90fbea64ed20ace71a863"
+        },
+        {
+          "package": "@gajae-code/natives",
+          "path": "native/loader-state.js",
+          "sha256": "7332a76de7195891429bf759c00737aef4f0b158b727c3b81cb920defe867e1f"
+        }
+      ]
     }
   },
   "sdkLifecycle": {


### PR DESCRIPTION
## What this changes

- Adds `linux-arm64` to `PLATFORMS` in `scripts/fetch-bun.mjs` with official Bun 1.4.0 `bun-linux-aarch64.zip` archive URL and SHA-256 digest (`4b1a332ee861983eb93bcfe6f770fff94e3e31b2c388bdaea3c8ed35e58eed0e`).
- Adds `linux-arm64` to `SUPPORTED_PLATFORMS` in `scripts/fill-runtime-manifest.mjs`.
- Records verified native file closures for `@gajae-code/natives-linux-arm64` in `server/gjc-runtime-manifest.json`.
- Adds contributor signature to `CLA.md`.

## Why

- Running the Gajae Code App server on Linux ARM64 machines (e.g. AWS Graviton, Oracle Cloud Ampere A1, Raspberry Pi 5, or Apple Silicon Docker containers) failed during bootstrap:
  1. `scripts/fetch-bun.mjs` threw `Error: Bun 1.4.0 is only bundled for linux-x64 and darwin-arm64; received linux-arm64.`
  2. `scripts/fill-runtime-manifest.mjs` threw `Error: GJC runtime manifest does not support linux-arm64.`
  3. `verifyRuntimeManifest` failed its platform closure check without the native hashes for `@gajae-code/natives-linux-arm64`.
- Note: This change specifically targets headless/web server and Docker deployment on Linux ARM64; desktop packaging remains focused on macOS Apple Silicon and x86_64 Linux per project roadmap.

## Verification

- `npm run check:sdk-patch` (verified 32 patch files)
- `npm run check:extract-zip-patch` (verified 1 patch file)
- `npm run check:identity` (passed: 2309 source, 811 generated scanned)
- `npm run typecheck` (passed on both tsconfig.json and server/tsconfig.json with 0 errors)
- `npm run lint` (eslint passed with 0 errors)
- `npm run check:licenses` (550 packages checked, 0 incompatible terms)
- `npm run check:notices` (matches dependency tree)
- `npm run check:core` (62 cargo tests passed, 0 failed)
- `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/gjc-runtime-manifest.test.ts` (14 passed, 0 failed)
- Verified runtime bootstrap and live server startup on Linux aarch64 (Ubuntu 24.04 ARM64).

---

- [x] I have signed the [Contributor License Agreement](../CLA.md), or I am the project owner.
- [x] `npm run verify` passes, or I have said below which gate fails and why.