### PR TITLE
fix(chat): resolve preset reference pins instead of showing them raw

### DIFF
--- a/shared/model-selectors.ts
+++ b/shared/model-selectors.ts
@@ -39,6 +39,17 @@ export function primaryModelSelector(value: string): string | undefined {
   return unquote(content.slice(0, end).trim());
 }
 
+/**
+ * Selection references (`default`, `profile:name`) name an entry in the preset
+ * catalog, not a concrete model the runtime reports or runs. Display slots
+ * that expect a model id must resolve them through the catalog instead of
+ * rendering them verbatim.
+ */
+export function isModelSelectionReference(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed === 'default' || trimmed.startsWith('profile:');
+}
+
 function unquote(value: string): string | undefined {
   if (!value) return undefined;
   if ((value.startsWith('"') && value.endsWith('"'))

--- a/src/components/chat/tests/modelAndReasoningPicker.test.ts
+++ b/src/components/chat/tests/modelAndReasoningPicker.test.ts
@@ -145,6 +145,24 @@ test('resolveDisplayModel prefers the live session model over every fallback', (
   );
 });
 
+test('a session pin that is a selection reference resolves through the preset catalog', () => {
+  // The composer feeds the session pin into `currentModel`; when the pin is
+  // `default` or `profile:*` it is a choice, not a runtime report, and must
+  // never surface verbatim on the trigger button.
+  assert.equal(
+    resolveDisplayModel('profile:codex-medium', 'profile:codex-medium', catalog),
+    'custom/codex',
+  );
+  assert.equal(resolveDisplayModel('default', 'default', catalog), 'openai/gpt-5.6-sol');
+  // An unknown reference still resolves through the Current preset.
+  assert.equal(resolveDisplayModel('profile:missing', 'profile:missing', catalog), 'openai/gpt-5.6-sol');
+  // A concrete runtime report keeps winning over every reference.
+  assert.equal(
+    resolveDisplayModel('profile:codex-medium', 'openai/live-model', catalog),
+    'openai/live-model',
+  );
+});
+
 test('resolveDisplayModel shows a raw selection when the session has not reported yet', () => {
   assert.equal(resolveDisplayModel('custom/codex', undefined, catalog), 'custom/codex');
 });

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -4,7 +4,7 @@ import { ArrowDownIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import PermissionContext from '../../../contexts/PermissionContext';
-import { readSessionFacts, readTokenTotals, type SessionStatusSnapshot } from '../../../contexts/sessionStatusSnapshot';
+import { displayModelId, readSessionFacts, readTokenTotals, type SessionStatusSnapshot } from '../../../contexts/sessionStatusSnapshot';
 import { usePublishSessionStatus } from '../../../contexts/SessionStatusContext';
 import { useWebSocket } from '../../../contexts/WebSocketContext';
 import { useLegacySkipPermissionsMigration, useProjectPermissions } from '../../../hooks/useProjectPermissions';
@@ -201,11 +201,11 @@ function ChatInterface({
 
   const sessionStatusSnapshot = useMemo<SessionStatusSnapshot>(() => {
     const reported = readSessionFacts(session.sessionState);
-    const fallbackModel = gjcModel && gjcModel !== 'default' ? gjcModel : undefined;
+    const fallbackModel = displayModelId(gjcModel);
     return {
       ...reported,
       sessionId: session.currentSessionId ?? selectedSession?.id ?? null,
-      modelId: sessionPinnedModel ?? reported.modelId ?? fallbackModel,
+      modelId: displayModelId(sessionPinnedModel, reported.modelId, fallbackModel),
       thinkingLevel: reported.thinkingLevel ?? reasoningEffort,
       tokens: readTokenTotals(session.tokenBudget),
       activity: {

--- a/src/components/chat/view/ModelAndReasoningPicker.tsx
+++ b/src/components/chat/view/ModelAndReasoningPicker.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Check, ChevronDown, ChevronRight, Loader2, Search } from 'lucide-react';
 
-import { primaryModelSelector } from '../../../../shared/model-selectors';
+import { isModelSelectionReference, primaryModelSelector } from '../../../../shared/model-selectors';
 import { cn } from '../../../utils/cn';
 import type { ProviderModelOption } from '../../../types/app';
 
@@ -150,13 +150,19 @@ export function filterSessionModelGroups(groups: SessionModelGroup[], query: str
  * Resolves which model id the trigger button should display: the live session
  * report wins, then an explicit raw selection, then the default-role model of
  * the selected (or current) preset.
+ *
+ * `currentModel` may arrive carrying a session pin instead of a runtime
+ * report; when that pin is itself a selection reference (`default`,
+ * `profile:name`) it is not a model id and must resolve through the preset
+ * catalog below rather than be displayed verbatim.
  */
 export function resolveDisplayModel(
   value: string,
   currentModel: string | undefined,
   presetOptions: ProviderModelOption[],
 ): string | undefined {
-  if (currentModel?.trim()) return stripEffortSuffix(currentModel.trim());
+  const live = currentModel?.trim();
+  if (live && !isModelSelectionReference(live)) return stripEffortSuffix(live);
   if (value && value !== DEFAULT_MODEL_VALUE && !value.startsWith('profile:')) return value;
   const preset = presetOptions.find((option) => option.value === value)
     ?? presetOptions.find((option) => option.value === DEFAULT_MODEL_VALUE);

--- a/src/contexts/sessionStatusSnapshot.test.ts
+++ b/src/contexts/sessionStatusSnapshot.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  displayModelId,
   EMPTY_SESSION_STATUS,
   formatTokens,
   readSessionFacts,
@@ -59,6 +60,15 @@ test('a percentage over the window is clamped instead of overflowing the bar', (
 
 test('no session state at all yields no facts', () => {
   assert.deepEqual(readSessionFacts(null), {});
+});
+
+test('displayModelId skips selection references and picks the first concrete model', () => {
+  // Session pins can be `default` or `profile:name`; the status row must show
+  // the model the runtime reported, never the raw reference.
+  assert.equal(displayModelId('profile:claude-opus', 'anthropic/claude-opus-5', 'default'), 'anthropic/claude-opus-5');
+  assert.equal(displayModelId('default', undefined), undefined);
+  assert.equal(displayModelId(null, '  ', ' zai/glm-5.3 '), 'zai/glm-5.3');
+  assert.equal(displayModelId('anthropic/claude-opus-5', 'profile:claude-opus'), 'anthropic/claude-opus-5');
 });
 
 test('token totals come from the reported fields, cache summed across read and write', () => {

--- a/src/contexts/sessionStatusSnapshot.ts
+++ b/src/contexts/sessionStatusSnapshot.ts
@@ -8,6 +8,8 @@
  * compare two snapshots without re-rendering the panel on every keystroke.
  */
 
+import { isModelSelectionReference } from '../../shared/model-selectors';
+
 export type SessionTokenTotals = {
   used: number;
   input?: number;
@@ -75,6 +77,20 @@ export function readSessionFacts(sessionState: Record<string, unknown> | null | 
     contextPercent: percent === undefined ? undefined : Math.min(100, percent),
     contextSource: text(sessionState.contextSource),
   };
+}
+
+/**
+ * First candidate usable as a model id for display. A session pin or app
+ * default can be a selection reference (`default`, `profile:name`) that names
+ * a preset rather than a model; those must not reach the status rows, which
+ * would render the raw reference verbatim.
+ */
+export function displayModelId(...candidates: Array<string | null | undefined>): string | undefined {
+  for (const candidate of candidates) {
+    const trimmed = typeof candidate === 'string' ? candidate.trim() : '';
+    if (trimmed && !isModelSelectionReference(trimmed)) return trimmed;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Problem

모델을 계속 다시 선택해도 컴포저의 모델 트리거에 `profile:claude-opus` 같은 문자열이 그대로 표시되는 경우가 있었다.

## Root cause

에이전트 설정(프리셋)을 고르면 세션 핀에 **선택 레퍼런스**(`default`, `profile:claude-opus`)가 저장된다 — 서버/워커는 이걸 역할 체인으로 해석해서 쓴다. 문제는 표시 계층:

- `ChatComposer`가 이 핀을 그대로 "runtime이 마지막에 보고한 모델" 슬롯(`currentModel`)에 넘기고,
- `resolveDisplayModel`은 `currentModel`을 무조건 신뢰해서 `profile:claude-opus` 문자열을 그대로 반환하며,
- `modelDisplayLabel`의 `compactModel`(`split('/').pop()`)는 `/`가 없는 이 문자열을 자르지 못해 **raw 문자열이 그대로 버튼 라벨이 된다**.

같은 핀이 상태 탭(`WorkspaceStatusTab`)에도 raw로 렌더링됐다. 프리셋을 다시 골러도 같은 레퍼런스가 다시 핀되므로 "계속 선택해도 안 바뀌는" 증상으로 보였다.

## Fix

- `resolveDisplayModel`: 레퍼런스 형태(`default`, `profile:*`)의 `currentModel`은 runtime 보고가 아니므로 무시하고, 이미 존재하는 프리셋 카탈로그 해석 경로로 폴스루 → `profile:claude-opus`는 default role 모델(예: `anthropic/claude-opus-5`)로 표시된다.
- 세션 상태 스냅샷: `displayModelId(...)`로 첫 번째 *구체적인* 모델만 선택 — 레퍼런스는 상태 행에 도달하지 않는다.
- 형태 판별은 `shared/model-selectors.ts`의 `isModelSelectionReference`로 한 곳에서.

부수 효과(개선): 트리거의 reasoning 라벨이 레퍼런스 문자열 대신 해석된 모델의 runtime 기본값을 따르게 된다.

## Verification

- `modelAndReasoningPicker.test.ts`: 레퍼런스 핀이 카탈로그를 통해 해석되는 케이스 추가 (`ok 9`)
- `sessionStatusSnapshot.test.ts`: `displayModelId` 케이스 추가 (`ok 24`)
- 포커스 테스트 30/30 통과, 관련 chat/workspace 테스트 26/26 통과
- `npm run typecheck` (client+server), eslint 통과
- `npm test`: server/client 전체 통과. 유일한 실패 `useAppMessageSender.dom.bun.test.tsx`(`React.act is not a function`)는 이 변경 없이 main HEAD에서도 동일하게 실패하는 선재 환경 문제 (stash로 검증)