### PR TITLE
test(desktop): deflake updater backend socket round-trip deadline

### DIFF
--- a/src-tauri/src/updater_backend.rs
+++ b/src-tauri/src/updater_backend.rs
@@ -230,12 +230,16 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    // Peer-thread round-trip must never race the deadline on a loaded CI runner;
+    // 1s flaked on macos-14 with "updater_backend_unavailable".
+    const TEST_DEADLINE: Duration = Duration::from_secs(30);
+
     #[test]
     fn exact_correlated_exchange_and_retirement() {
         let (native, mut node) = UnixStream::pair().unwrap();
         let backend = Backend::new(native, "a".repeat(64)).unwrap();
         let peer = std::thread::spawn(move || {
-            let request = read_frame(&mut node, Instant::now() + Duration::from_secs(1)).unwrap();
+            let request = read_frame(&mut node, Instant::now() + TEST_DEADLINE).unwrap();
             assert_eq!(request["command"], serde_json::json!({"action":"status"}));
             let reply = serde_json::json!({"protocolVersion":1,"kind":"restartControlResult","epoch":request["epoch"],"id":request["id"],
                 "result":{"ok":true,"state":"open","attemptId":null,"token":null,"expiresInMs":null,"error":null}});
@@ -243,14 +247,14 @@ mod tests {
         });
         assert_eq!(
             backend
-                .request(Control::Status, Instant::now() + Duration::from_secs(1))
+                .request(Control::Status, Instant::now() + TEST_DEADLINE)
                 .unwrap()
                 .state,
             State::Open
         );
         backend.retire();
         assert!(backend
-            .request(Control::Status, Instant::now() + Duration::from_secs(1))
+            .request(Control::Status, Instant::now() + TEST_DEADLINE)
             .is_err());
         peer.join().unwrap();
     }
@@ -264,12 +268,11 @@ mod tests {
             let (native, mut node) = UnixStream::pair().unwrap();
             let backend = Backend::new(native, "b".repeat(64)).unwrap();
             let peer = std::thread::spawn(move || {
-                let request =
-                    read_frame(&mut node, Instant::now() + Duration::from_secs(1)).unwrap();
+                let request = read_frame(&mut node, Instant::now() + TEST_DEADLINE).unwrap();
                 writeln!(node, "{}", serde_json::json!({"protocolVersion":1,"kind":"restartControlResult","epoch":request["epoch"],"id":request["id"],"result":malformed})).unwrap();
             });
             assert!(backend
-                .request(Control::Status, Instant::now() + Duration::from_secs(1))
+                .request(Control::Status, Instant::now() + TEST_DEADLINE)
                 .is_err());
             assert!(!backend.available());
             peer.join().unwrap();


### PR DESCRIPTION
## Problem

`updater_backend::tests::exact_correlated_exchange_and_retirement` failed on the macos-14 desktop lane for #56 (a PR that touches no Rust) with `called Result::unwrap() on an Err value: "updater_backend_unavailable"` at `updater_backend.rs:247`. The test runs a Unix-socket round-trip through a spawned peer thread under a 1-second deadline; with 343 tests running in parallel on a loaded runner the deadline is exceeded and `request_inner` bails. The same code passed on main the day before, so this is a timing flake.

## Fix

Test module only: a single `TEST_DEADLINE = 30s` const replaces the five `Duration::from_secs(1)` deadlines in `exact_correlated_exchange_and_retirement` and `forged_or_incomplete_results_retire_the_channel`. Production deadline handling in `Backend` is untouched.

## Verification

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` exit 0
- `env -u CI cargo test --manifest-path src-tauri/Cargo.toml --bin gajae-app-desktop updater_backend`: 2 passed, 0 failed