### PR TITLE
fix(i18n): drop stray trailing periods from Japanese labels

### DIFF
--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -20,95 +20,95 @@
     "guidance": "各実行は {{turns}} モデルステップまたは {{minutes}} 分で一時停止します。停止すると目標が一時停止します。再開すると、実行中の処理がなければ新しい実行を開始します。委任したタスクも同じモデルと権限を使用します。"
   },
   "codeBlock": {
-    "copy": "コピー。",
-    "copied": "コピーしました。",
-    "copyCode": "コードをコピー。"
+    "copy": "コピー",
+    "copied": "コピーしました",
+    "copyCode": "コードをコピー"
   },
   "copyMessage": {
-    "copy": "メッセージをコピー。",
-    "copied": "メッセージをコピーしました。",
-    "selectFormat": "コピー形式を選択。",
-    "copyAsMarkdown": "Markdownとしてコピー。",
-    "copyAsText": "テキストとしてコピー。"
+    "copy": "メッセージをコピー",
+    "copied": "メッセージをコピーしました",
+    "selectFormat": "コピー形式を選択",
+    "copyAsMarkdown": "Markdownとしてコピー",
+    "copyAsText": "テキストとしてコピー"
   },
   "messageTypes": {
-    "claude": "Claude。",
-    "cursor": "Cursor。",
-    "codex": "Codex。",
-    "opencode": "OpenCode。",
+    "claude": "Claude",
+    "cursor": "Cursor",
+    "codex": "Codex",
+    "opencode": "OpenCode",
     "notice": {
-      "info": "お知らせ。",
-      "warning": "警告。",
-      "error": "エラー。"
+      "info": "お知らせ",
+      "warning": "警告",
+      "error": "エラー"
     }
   },
   "tools": {
-    "error": "ツールエラー。",
+    "error": "ツールエラー",
     "rawParams": "生パラメータ"
   },
   "search": {
-    "in": "場所:。"
+    "in": "場所:"
   },
   "interactive": {
-    "title": "インタラクティブプロンプト。",
-    "waiting": "CLIでの応答を待っています。",
+    "title": "インタラクティブプロンプト",
+    "waiting": "CLIでの応答を待っています",
     "instruction": "Claudeが実行されているターミナルでオプションを選択してください。"
   },
   "json": {
-    "response": "JSONレスポンス。"
+    "response": "JSONレスポンス"
   },
   "voice": {
-    "input": "メッセージを音声入力。",
-    "stopRecording": "録音を終了。",
-    "speak": "応答を読み上げ。",
-    "stopSpeaking": "停止。",
+    "input": "メッセージを音声入力",
+    "stopRecording": "録音を終了",
+    "speak": "応答を読み上げ",
+    "stopSpeaking": "停止",
     "loading": "読み込み中…"
   },
   "input": {
-    "placeholder": "/ でコマンド、@ でファイル指定、または {{provider}} に何でも聞いてください...。",
+    "placeholder": "/ でコマンド、@ でファイル指定、または {{provider}} に何でも聞いてください...",
     "modelReasoning": {
-      "label": "モデルと推論。",
-      "providerTitle": "プロバイダー。",
-      "modelTitle": "チャットモデル。",
-      "reasoningTitle": "推論。",
-      "defaultModel": "デフォルト。",
-      "currentConfiguration": "現在の設定を使用。",
+      "label": "モデルと推論",
+      "providerTitle": "プロバイダー",
+      "modelTitle": "チャットモデル",
+      "reasoningTitle": "推論",
+      "defaultModel": "デフォルト",
+      "currentConfiguration": "現在の設定を使用",
       "signInRequired": "このモデルを使うには、設定で {{provider}} にサインインしてください",
       "search": "プロバイダーやモデルを検索",
       "noMatches": "一致なし"
     },
     "agentConfiguration": {
-      "label": "エージェント設定。",
-      "title": "エージェント設定。",
+      "label": "エージェント設定",
+      "title": "エージェント設定",
       "description": "チャット、プランナー、エグゼキューター、アーキテクト、クリティックの各ロールで使用するモデルを選択します。",
-      "search": "設定を検索。",
+      "search": "設定を検索",
       "noMatches": "一致する設定がありません。",
       "signInRequired": "このプリセットを使うには、設定で {{provider}} にサインインしてください"
     },
-    "attachImages": "画像を添付。",
-    "send": "送信。",
-    "stop": "停止。",
+    "attachImages": "画像を添付",
+    "send": "送信",
+    "stop": "停止",
     "hintText": {
-      "ctrlEnter": "Ctrl+Enterで送信 • Shift+Enterで改行 • Tabでモード切替 • / でスラッシュコマンド。",
-      "enter": "Enterで送信 • Shift+Enterで改行 • Tabでモード切替 • / でスラッシュコマンド。",
-      "queue": "Enter で次のメッセージをキューに追加。"
+      "ctrlEnter": "Ctrl+Enterで送信 • Shift+Enterで改行 • Tabでモード切替 • / でスラッシュコマンド",
+      "enter": "Enterで送信 • Shift+Enterで改行 • Tabでモード切替 • / でスラッシュコマンド",
+      "queue": "Enter で次のメッセージをキューに追加"
     },
-    "scrollToBottom": "最新へ移動。",
+    "scrollToBottom": "最新へ移動",
     "queue": {
       "reviewBeforeSending": "編集して確認してから送信",
       "recoveryNotice": "重複送信を防ぐため、復元した待機メッセージの自動送信を保留しました。メッセージを編集して内容と添付ファイルを確認してから送信してください。現在の下書きは保持されます。",
-      "sendNext": "次のメッセージをキューに追加。",
-      "label": "待機中。",
-      "willSend": "現在の処理が終わったら送信。",
-      "willFollow": "上のメッセージの後に送信。",
+      "sendNext": "次のメッセージをキューに追加",
+      "label": "待機中",
+      "willSend": "現在の処理が終わったら送信",
+      "willFollow": "上のメッセージの後に送信",
       "awaitingSteer": "追加指示の受理待ち",
-      "edit": "待機中のメッセージを編集。",
-      "delete": "待機中のメッセージを削除。",
-      "moveUp": "キューの前へ移動。",
-      "moveDown": "キューの後ろへ移動。",
-      "images_one": "画像を {{count}} 件追加。",
-      "images_other": "画像 {{count}} 件を添付。",
-      "steerNow": "実行中の処理にそのまま送信。"
+      "edit": "待機中のメッセージを編集",
+      "delete": "待機中のメッセージを削除",
+      "moveUp": "キューの前へ移動",
+      "moveDown": "キューの後ろへ移動",
+      "images_one": "画像を {{count}} 件追加",
+      "images_other": "画像 {{count}} 件を添付",
+      "steerNow": "実行中の処理にそのまま送信"
     },
     "draftPersistence": {
       "failed": "下書きを保存できませんでした。このウィンドウを閉じないでください。",
@@ -128,28 +128,28 @@
   },
   "session": {
     "loading": {
-      "olderMessages": "過去のメッセージを読み込んでいます...。",
+      "olderMessages": "過去のメッセージを読み込んでいます...",
       "olderMessagesFailed": "過去のメッセージを読み込めませんでした。",
       "retry": "再試行",
-      "sessionMessages": "セッションメッセージを読み込んでいます...。"
+      "sessionMessages": "セッションメッセージを読み込んでいます..."
     },
     "messages": {
-      "loadEarlier": "過去のメッセージを読み込む。",
-      "loadAll": "すべてのメッセージを取得。",
-      "loadFullToolOutput": "完全な出力を読み込む。",
-      "loadingFullToolOutput": "完全な出力を読み込み中...。",
+      "loadEarlier": "過去のメッセージを読み込む",
+      "loadAll": "すべてのメッセージを取得",
+      "loadFullToolOutput": "完全な出力を読み込む",
+      "loadingFullToolOutput": "完全な出力を読み込み中...",
       "fullToolOutputFailed": "完全な出力を読み込めませんでした。",
       "loadingAll": "すべてのメッセージを取得中…",
-      "allLoaded": "すべてのメッセージを読み込みました。"
+      "allLoaded": "すべてのメッセージを読み込みました"
     }
   },
   "shell": {
-    "loading": "ターミナルを読み込んでいます...。"
+    "loading": "ターミナルを読み込んでいます..."
   },
   "claudeStatus": {
     "elapsed": {
-      "seconds": "{{count}}s。",
-      "minutesSeconds": "{{minutes}}m {{seconds}}s。"
+      "seconds": "{{count}}s",
+      "minutesSeconds": "{{minutes}}m {{seconds}}s"
     }
   },
   "activity": {
@@ -191,7 +191,7 @@
     "otherTools_other": "その他のツール {{count}} 件"
   },
   "projectSelection": {
-    "startChatWithProvider": "{{provider}} と会話する前にプロジェクトを選択してください。"
+    "startChatWithProvider": "{{provider}} と会話する前にプロジェクトを選択してください"
   },
   "newSession": {
     "greeting": "今日は何を作りましょうか？",
@@ -199,9 +199,9 @@
   },
   "reasoning": {
     "thinking": "思考中…",
-    "thoughtBriefly": "少し考えました。",
-    "thoughtFor_one": "{{count}} 秒間推論しました。",
-    "thoughtFor_other": "{{count}} 秒考えました。"
+    "thoughtBriefly": "少し考えました",
+    "thoughtFor_one": "{{count}} 秒間推論しました",
+    "thoughtFor_other": "{{count}} 秒考えました"
   },
   "toolOutputDensity": {
     "tooltip": "ツール出力: {{level}} ({{shortcut}})",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1,18 +1,18 @@
 {
   "buttons": {
-    "cancel": "キャンセル。"
+    "cancel": "キャンセル"
   },
   "tabs": {
-    "chat": "チャット。",
-    "git": "ソース管理。"
+    "chat": "チャット",
+    "git": "ソース管理"
   },
   "status": {
-    "success": "成功。"
+    "success": "成功"
   },
   "mainContent": {
-    "loading": "Gajae Code App を読み込んでいます。",
-    "settingUpWorkspace": "ワークスペースを準備しています...。",
-    "chooseProject": "プロジェクトを選択。",
+    "loading": "Gajae Code App を読み込んでいます",
+    "settingUpWorkspace": "ワークスペースを準備しています...",
+    "chooseProject": "プロジェクトを選択",
     "selectProjectDescription": "サイドバーからプロジェクトを選択して、Gajae Codeとコーディングを始めましょう。各プロジェクトにはチャットセッションとファイル履歴が含まれています。",
     "firstProject": "最初のプロジェクトを追加",
     "firstProjectDescription": "このマシン上のフォルダを選びます。Gajae Code はその中で作業し、プロジェクトの会話もそこに残ります。",
@@ -21,56 +21,56 @@
     "scratchStarting": "準備中…",
     "scratchDescription": "まだフォルダがありませんか？Gajae Code が使い捨ての git リポジトリ ~/gajae-scratch を作成し、そこで会話を開きます。エージェントはその中だけで作業します。",
     "scratchFailed": "スクラッチ用ワークスペースを開始できませんでした: {{reason}}",
-    "newSession": "新しいセッション。",
-    "projectFiles": "プロジェクトファイル。"
+    "newSession": "新しいセッション",
+    "projectFiles": "プロジェクトファイル"
   },
   "projectWizard": {
     "step2": {
-      "existingPath": "ワークスペースのパス。",
-      "existingPlaceholder": "/path/to/existing/workspace。"
+      "existingPath": "ワークスペースのパス",
+      "existingPlaceholder": "/path/to/existing/workspace"
     },
     "buttons": {
-      "cancel": "キャンセル。",
-      "creating": "作成中...。"
+      "cancel": "キャンセル",
+      "creating": "作成中..."
     },
     "errors": {
-      "providePath": "ワークスペースのパスを入力してください。",
-      "failedToCreate": "ワークスペースの作成に失敗しました。"
+      "providePath": "ワークスペースのパスを入力してください",
+      "failedToCreate": "ワークスペースの作成に失敗しました"
     },
     "folderBrowser": {
-      "title": "フォルダを選択。",
-      "showHiddenFolders": "隠しフォルダを表示。",
-      "hideHiddenFolders": "隠しフォルダを非表示。",
-      "createNewFolder": "新しいフォルダを作成。",
-      "close": "フォルダブラウザを閉じる。",
-      "newFolderName": "新しいフォルダ名。",
-      "create": "作成。",
-      "cancel": "キャンセル。",
-      "failedToLoad": "フォルダの読み込みに失敗しました。",
-      "failedToCreate": "フォルダの作成に失敗しました。",
-      "noSubfolders": "サブフォルダが見つかりません。",
-      "path": "パス:。",
-      "useThisFolder": "このフォルダを使用。",
-      "browseFolders": "フォルダを参照。"
+      "title": "フォルダを選択",
+      "showHiddenFolders": "隠しフォルダを表示",
+      "hideHiddenFolders": "隠しフォルダを非表示",
+      "createNewFolder": "新しいフォルダを作成",
+      "close": "フォルダブラウザを閉じる",
+      "newFolderName": "新しいフォルダ名",
+      "create": "作成",
+      "cancel": "キャンセル",
+      "failedToLoad": "フォルダの読み込みに失敗しました",
+      "failedToCreate": "フォルダの作成に失敗しました",
+      "noSubfolders": "サブフォルダが見つかりません",
+      "path": "パス:",
+      "useThisFolder": "このフォルダを使用",
+      "browseFolders": "フォルダを参照"
     }
   },
   "versionUpdate": {
     "ariaLabels": {
-      "showSidebar": "サイドバーを表示。",
-      "closeSidebar": "サイドバーを閉じる。"
+      "showSidebar": "サイドバーを表示",
+      "closeSidebar": "サイドバーを閉じる"
     }
   },
   "workspace": {
-    "title": "ワークスペース。",
-    "open": "ワークスペースパネルを開く。",
-    "close": "ワークスペースパネルを閉じる。",
-    "expand": "ワークスペースパネルを展開。",
-    "collapse": "ワークスペースパネルを折りたたむ。",
-    "resize": "ドラッグしてワークスペースパネルのサイズを変更。",
+    "title": "ワークスペース",
+    "open": "ワークスペースパネルを開く",
+    "close": "ワークスペースパネルを閉じる",
+    "expand": "ワークスペースパネルを展開",
+    "collapse": "ワークスペースパネルを折りたたむ",
+    "resize": "ドラッグしてワークスペースパネルのサイズを変更",
     "tabs": {
-      "status": "ステータス。",
+      "status": "ステータス",
       "changes": "変更",
-      "browser": "Browser。",
+      "browser": "Browser",
       "tasks": "タスク"
     },
     "changes": {
@@ -123,64 +123,64 @@
       }
     },
     "browser": {
-      "address": "Web アドレス。",
-      "back": "戻る。",
-      "forward": "進む。",
-      "reload": "ページを再読み込み。",
-      "external": "既定のブラウザで開く。",
-      "stop": "ブラウザセッションを終了。",
-      "preview": "Chromium ライブプレビュー。",
+      "address": "Web アドレス",
+      "back": "戻る",
+      "forward": "進む",
+      "reload": "ページを再読み込み",
+      "external": "既定のブラウザで開く",
+      "stop": "ブラウザセッションを終了",
+      "preview": "Chromium ライブプレビュー",
       "empty": "URL を入力するか、ローカルの開発用アドレスを選択してください。",
-      "installTitle": "開発用ブラウザをインストール。",
+      "installTitle": "開発用ブラウザをインストール",
       "installDescription": "Gajae は Chrome for Testing を別途ダウンロードし、分離されたブラウザプロファイルを使用します。",
-      "download": "Chromium を取得して起動。",
+      "download": "Chromium を取得して起動",
       "preparing": "Chromium を準備中…",
       "downloading": "Chromium を取得中… {{progress}}%",
       "connecting": "開発用ブラウザに接続中…",
-      "newTab": "タブを開く。",
-      "closeTab": "タブを閉じる。",
+      "newTab": "タブを開く",
+      "closeTab": "タブを閉じる",
       "connection": {
-        "connecting": "接続中。",
-        "live": "接続済み。",
-        "offline": "オフライン。"
+        "connecting": "接続中",
+        "live": "接続済み",
+        "offline": "オフライン"
       },
       "unsupported": "自動化プレビューには Apple Silicon と macOS 14 以降が必要です。",
       "error": "ブラウザ自動化を開始できませんでした。",
       "downloadBlocked": "ダウンロードをブロックしました: {{filename}}。このプレビューではダウンロードを保存できません。",
-      "downloadUnknown": "ダウンロード。",
-      "dialogDismissed": "Gajae がページダイアログを閉じました: {{message}}。",
-      "cua": "ネイティブアプリ · CUA Driver。",
-      "cuaMissing": "利用不可。"
+      "downloadUnknown": "ダウンロード",
+      "dialogDismissed": "Gajae がページダイアログを閉じました: {{message}}",
+      "cua": "ネイティブアプリ · CUA Driver",
+      "cuaMissing": "利用不可"
     },
     "statusTab": {
-      "session": "セッション。",
-      "model": "モデル。",
-      "reasoning": "推論レベル。",
-      "context": "コンテキスト。",
-      "contextWindow": "コンテキストウィンドウ。",
-      "tokens": "トークン。",
-      "tokensUsed": "使用。",
-      "tokensInput": "入力。",
-      "tokensOutput": "出力。",
-      "tokensCache": "キャッシュ。",
-      "activity": "アクティビティ。",
-      "running": "実行中。",
-      "idle": "待機中。",
-      "queuedMessage": "待機中のメッセージ 1 件。",
-      "location": "場所。",
-      "project": "プロジェクト。",
-      "directory": "ディレクトリ。",
-      "git": "Git。",
-      "branch": "ブランチ。",
-      "changes": "変更。",
-      "staged": "ステージ済み。",
-      "untracked": "未追跡。",
-      "clean": "ローカルの変更なし。",
-      "notARepository": "Git リポジトリではありません。",
-      "gitUnavailable": "Git ステータスを取得できません。",
-      "refreshGit": "Git ステータスを更新。",
-      "unreported": "まだ報告されていません。",
-      "empty": "開いているセッションがありません。",
+      "session": "セッション",
+      "model": "モデル",
+      "reasoning": "推論レベル",
+      "context": "コンテキスト",
+      "contextWindow": "コンテキストウィンドウ",
+      "tokens": "トークン",
+      "tokensUsed": "使用",
+      "tokensInput": "入力",
+      "tokensOutput": "出力",
+      "tokensCache": "キャッシュ",
+      "activity": "アクティビティ",
+      "running": "実行中",
+      "idle": "待機中",
+      "queuedMessage": "待機中のメッセージ 1 件",
+      "location": "場所",
+      "project": "プロジェクト",
+      "directory": "ディレクトリ",
+      "git": "Git",
+      "branch": "ブランチ",
+      "changes": "変更",
+      "staged": "ステージ済み",
+      "untracked": "未追跡",
+      "clean": "ローカルの変更なし",
+      "notARepository": "Git リポジトリではありません",
+      "gitUnavailable": "Git ステータスを取得できません",
+      "refreshGit": "Git ステータスを更新",
+      "unreported": "まだ報告されていません",
+      "empty": "開いているセッションがありません",
       "emptyHint": "セッションを開くか開始すると、実行内容がここに表示されます。",
       "permissions": "権限"
     }

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -73,36 +73,36 @@
     }
   },
   "close": "設定を閉じる",
-  "title": "設定。",
+  "title": "設定",
   "account": {
-    "language": "言語。",
-    "languageLabel": "表示言語。",
-    "languageDescription": "インターフェースの表示言語を選択してください。"
+    "language": "言語",
+    "languageLabel": "表示言語",
+    "languageDescription": "インターフェースの表示言語を選択してください"
   },
   "voiceSettings": {
-    "title": "Voice。",
+    "title": "Voice",
     "description": "Speech-to-text input and read-aloud, via an OpenAI-compatible audio backend.。",
-    "enable": "Enable voice。",
+    "enable": "Enable voice",
     "enableDescription": "Show the mic button and the read-aloud button on messages.。",
-    "backendTitle": "Backend。",
+    "backendTitle": "Backend",
     "backendDescription": "Point at OpenAI, Groq, or a local server (LocalAI, Speaches, Kokoro-FastAPI). Leave blank to use the server default.。",
-    "baseUrl": "Base URL。",
-    "apiKey": "API key。",
-    "sttModel": "Speech-to-text model。",
-    "ttsModel": "Text-to-speech model。",
-    "voice": "Voice。",
-    "format": "Audio format。",
+    "baseUrl": "Base URL",
+    "apiKey": "API key",
+    "sttModel": "Speech-to-text model",
+    "ttsModel": "Text-to-speech model",
+    "voice": "Voice",
+    "format": "Audio format",
     "note": "A custom base URL is called directly by your browser and must allow browser CORS requests. Leave it blank to use the server-configured backend.。"
   },
   "preferences": {
     "sections": {
-      "toolDisplay": "ツール表示。",
-      "inputSettings": "入力設定。",
+      "toolDisplay": "ツール表示",
+      "inputSettings": "入力設定",
       "experimental": "実験的機能"
     },
-    "showRawParameters": "生パラメータを表示。",
-    "showThinking": "思考を表示。",
-    "sendByCtrlEnter": "Ctrl+Enterで送信。",
+    "showRawParameters": "生パラメータを表示",
+    "showThinking": "思考を表示",
+    "sendByCtrlEnter": "Ctrl+Enterで送信",
     "sendByCtrlEnterDescription": "有効にすると、Enterではなく Ctrl+Enter でメッセージを送信します。IMEユーザーの誤送信防止に便利です。",
     "agentSidebarV2": "エージェントサイドバー（プレビュー）",
     "agentSidebarV2Description": "ワークスペースパネルを新しいエージェントサイドバーに置き換えます。現時点では空の状態のみ表示されます。",
@@ -118,100 +118,100 @@
     }
   },
   "mainTabs": {
-    "appearance": "外観。",
-    "git": "Git。",
-    "voice": "音声。",
-    "notifications": "通知。",
-    "automation": "Automation。",
-    "about": "概要。",
+    "appearance": "外観",
+    "git": "Git",
+    "voice": "音声",
+    "notifications": "通知",
+    "automation": "Automation",
+    "about": "概要",
     "permissions": "権限"
   },
   "automation": {
-    "title": "ブラウザとネイティブアプリケーション。",
+    "title": "ブラウザとネイティブアプリケーション",
     "description": "分離された Chromium ランタイムと別途インストールされた CUA Driver を確認します。",
-    "chromium": "分離された Chromium ランタイム。",
-    "notDownloaded": "ブラウザパネルを初めて開いたときにダウンロードされます。",
-    "notInstalled": "利用不可。",
-    "installGuide": "セットアップ手順。",
-    "accessibility": "アクセシビリティ。",
-    "screenRecording": "画面を録画。",
-    "granted": "許可済み。",
-    "missing": "未許可。",
-    "unknown": "不明。",
-    "refresh": "診断を再読み込み。",
-    "grants": "常に許可された対象。",
+    "chromium": "分離された Chromium ランタイム",
+    "notDownloaded": "ブラウザパネルを初めて開いたときにダウンロードされます",
+    "notInstalled": "利用不可",
+    "installGuide": "セットアップ手順",
+    "accessibility": "アクセシビリティ",
+    "screenRecording": "画面を録画",
+    "granted": "許可済み",
+    "missing": "未許可",
+    "unknown": "不明",
+    "refresh": "診断を再読み込み",
+    "grants": "常に許可された対象",
     "grantsDescription": "「常に許可」とした対象のみ保存されます。",
     "noGrants": "保存された自動化の承認はありません。",
-    "origin": "サイトのオリジン。",
-    "application": "デスクトップアプリケーション。",
-    "revoke": "承認を削除。"
+    "origin": "サイトのオリジン",
+    "application": "デスクトップアプリケーション",
+    "revoke": "承認を削除"
   },
   "notifications": {
-    "title": "通知。",
+    "title": "通知",
     "description": "受信する通知イベントを設定します。",
     "desktop": {
-      "title": "デスクトップアプリの通知。",
-      "enable": "通知をオンにする。",
-      "disable": "通知をオフにする。",
-      "enabled": "このデスクトップアプリは通知を表示できます。",
+      "title": "デスクトップアプリの通知",
+      "enable": "通知をオンにする",
+      "disable": "通知をオフにする",
+      "enabled": "このデスクトップアプリは通知を表示できます",
       "unsupported": "このシステムはデスクトップ通知に対応していません。"
     },
     "sound": {
-      "title": "サウンド。",
+      "title": "サウンド",
       "description": "チャット実行が完了したときに短い音を再生します。",
-      "enabled": "有効。",
-      "test": "サウンドをテスト。"
+      "enabled": "有効",
+      "test": "サウンドをテスト"
     },
     "events": {
-      "title": "イベント種別。",
-      "actionRequired": "対応が必要。",
-      "stop": "実行停止。",
-      "error": "実行失敗。"
+      "title": "イベント種別",
+      "actionRequired": "対応が必要",
+      "stop": "実行停止",
+      "error": "実行失敗"
     }
   },
   "appearanceSettings": {
     "darkMode": {
-      "label": "ダークモード。",
-      "description": "ライトテーマとダークテーマを切り替えます。"
+      "label": "ダークモード",
+      "description": "ライトテーマとダークテーマを切り替えます"
     },
     "interfaceFontSize": {
-      "label": "インターフェースの文字サイズ。",
-      "description": "チャット、セッション、設定など画面全体の文字サイズを変更します。",
-      "small": "小。",
-      "medium": "中。",
-      "large": "大。"
+      "label": "インターフェースの文字サイズ",
+      "description": "チャット、セッション、設定など画面全体の文字サイズを変更します",
+      "small": "小",
+      "medium": "中",
+      "large": "大"
     },
     "imagePreviews": {
-      "label": "画像プレビュー。",
-      "description": "チャット履歴の添付画像を読み込んで表示します。"
+      "label": "画像プレビュー",
+      "description": "チャット履歴の添付画像を読み込んで表示します"
     },
     "projectSorting": {
-      "label": "プロジェクトの並び順。",
-      "description": "サイドバーでのプロジェクトの並び順を設定します。",
-      "alphabetical": "アルファベット順。",
-      "recentActivity": "最近のアクティビティ順。"
+      "label": "プロジェクトの並び順",
+      "description": "サイドバーでのプロジェクトの並び順を設定します",
+      "alphabetical": "アルファベット順",
+      "recentActivity": "最近のアクティビティ順"
     }
   },
   "saveStatus": {
     "success": "設定を保存しました！"
   },
   "git": {
-    "title": "Git設定。",
+    "title": "Git設定",
     "description": "コミット用のGit IDを設定します。この設定は git config --global で適用されます。",
     "name": {
-      "label": "Git名前。",
-      "help": "コミットに使用する名前。"
+      "label": "Git名前",
+      "help": "コミットに使用する名前"
     },
     "email": {
-      "label": "Gitメールアドレス。",
-      "help": "コミットに使用するメールアドレス。"
+      "label": "Gitメールアドレス",
+      "help": "コミットに使用するメールアドレス"
     },
     "actions": {
-      "save": "設定を保存。",
-      "saving": "保存中...。"
+      "save": "設定を保存",
+      "saving": "保存中..."
     },
     "status": {
-      "success": "保存しました。"
+      "success": "保存しました"
     }
   },
   "permissions": {

--- a/src/i18n/locales/ja/sidebar.json
+++ b/src/i18n/locales/ja/sidebar.json
@@ -1,51 +1,51 @@
 {
   "projects": {
-    "title": "ワークスペース。",
-    "newProject": "プロジェクトを追加。",
-    "deleteProject": "ワークスペースを削除。",
-    "renameProject": "ワークスペースの名前を変更。",
-    "noProjects": "ワークスペースはまだありません。",
+    "title": "ワークスペース",
+    "newProject": "プロジェクトを追加",
+    "deleteProject": "ワークスペースを削除",
+    "renameProject": "ワークスペースの名前を変更",
+    "noProjects": "ワークスペースはまだありません",
     "addFirst": "追加",
     "loadingProjects": "ワークスペースを取得中…",
-    "projectNamePlaceholder": "ワークスペース名。",
-    "untitledSession": "無題のセッション。",
-    "newSession": "会話を開始。",
-    "fetchingProjects": "プロジェクトと会話を取得中。",
-    "projects": "プロジェクト。"
+    "projectNamePlaceholder": "ワークスペース名",
+    "untitledSession": "無題のセッション",
+    "newSession": "会話を開始",
+    "fetchingProjects": "プロジェクトと会話を取得中",
+    "projects": "プロジェクト"
   },
   "sessions": {
-    "work": "作業。",
-    "newTask": "新しい作業項目。",
-    "newSession": "会話を開始。",
-    "deleteSession": "会話を削除。",
-    "renameSession": "会話の名前を変更。",
+    "work": "作業",
+    "newTask": "新しい作業項目",
+    "newSession": "会話を開始",
+    "deleteSession": "会話を削除",
+    "renameSession": "会話の名前を変更",
     "regenerateTitle": "タイトルを再生成",
-    "exportSession": "Markdown でエクスポート。",
+    "exportSession": "Markdown でエクスポート",
     "copyDebugInfo": "デバッグ情報をコピー",
-    "pin": "固定。",
-    "unpin": "固定を解除。",
-    "noSessions": "会話はまだありません。",
+    "pin": "固定",
+    "unpin": "固定を解除",
+    "noSessions": "会話はまだありません",
     "loadingSessions": "会話を取得中…",
-    "unnamed": "名称未設定。",
-    "loading": "読み込み中...。",
-    "showMore": "会話をさらに表示。"
+    "unnamed": "名称未設定",
+    "loading": "読み込み中...",
+    "showMore": "会話をさらに表示"
   },
   "tooltips": {
-    "hideSidebar": "サイドバーを隠す。",
-    "createProject": "プロジェクトを追加。",
-    "createSession": "会話を開始。",
-    "refresh": "プロジェクトと会話を再読み込み (Ctrl+R)。",
-    "renameProject": "プロジェクト名を変更 (F2)。",
-    "deleteProject": "サイドバーからプロジェクトを除去 (Delete)。",
-    "addToFavorites": "お気に入りに追加。",
-    "removeFromFavorites": "お気に入りから削除。",
-    "editSessionName": "会話名を編集。",
-    "sessionActions": "会話の操作。",
-    "deleteSession": "この会話を完全に削除。",
-    "activeSessionIndicator": "最近アクティブなセッション（過去10分以内）。",
-    "save": "保存。",
-    "cancel": "キャンセル。",
-    "attentionRequiredIndicator": "会話に対応が必要です。"
+    "hideSidebar": "サイドバーを隠す",
+    "createProject": "プロジェクトを追加",
+    "createSession": "会話を開始",
+    "refresh": "プロジェクトと会話を再読み込み (Ctrl+R)",
+    "renameProject": "プロジェクト名を変更 (F2)",
+    "deleteProject": "サイドバーからプロジェクトを除去 (Delete)",
+    "addToFavorites": "お気に入りに追加",
+    "removeFromFavorites": "お気に入りから削除",
+    "editSessionName": "会話名を編集",
+    "sessionActions": "会話の操作",
+    "deleteSession": "この会話を完全に削除",
+    "activeSessionIndicator": "最近アクティブなセッション（過去10分以内）",
+    "save": "保存",
+    "cancel": "キャンセル",
+    "attentionRequiredIndicator": "会話に対応が必要です"
   },
   "filter": {
     "placeholder": "会話を絞り込む",
@@ -53,15 +53,15 @@
     "noMatches": "「{{query}}」に一致する会話はありません"
   },
   "actions": {
-    "search": "検索。",
-    "settings": "設定。",
-    "cancel": "キャンセル。",
-    "save": "保存。",
-    "joinCommunity": "コミュニティに参加。",
-    "reportIssue": "問題を報告。"
+    "search": "検索",
+    "settings": "設定",
+    "cancel": "キャンセル",
+    "save": "保存",
+    "joinCommunity": "コミュニティに参加",
+    "reportIssue": "問題を報告"
   },
   "status": {
-    "thinking": "思考中...。",
+    "thinking": "思考中...",
     "running": "実行中",
     "needsInput": "入力待ち",
     "ready": "完了、まだ未確認",
@@ -95,14 +95,14 @@
     "debugInfoError": "デバッグ情報をコピーできませんでした。"
   },
   "version": {
-    "updateAvailable": "アップデートあり。"
+    "updateAvailable": "アップデートあり"
   },
   "deleteConfirmation": {
-    "deleteProject": "ワークスペースを削除。",
-    "deleteSession": "会話を削除。",
-    "confirmDelete": "このプロジェクトをどうしますか：。",
+    "deleteProject": "ワークスペースを削除",
+    "deleteSession": "会話を削除",
+    "confirmDelete": "このプロジェクトをどうしますか：",
     "sessionCount_one": "このプロジェクトには会話が {{count}} 件あります。",
     "sessionCount_other": "このプロジェクトには会話が {{count}} 件あります。",
-    "deleteAllData": "すべてのデータを完全に削除。"
+    "deleteAllData": "すべてのデータを完全に削除"
   }
 }


### PR DESCRIPTION
## Why

`src/i18n/locales/ja/*.json` carried a machine-translation artifact: a trailing `。` on short UI values that are not sentences — buttons (`"キャンセル。"`), tab names (`"Browser。"`), aria-labels, tooltips, a colon-terminated label (`"パス:。"`), ellipsis states (`"作成中...。"`) and even a placeholder path (`"/path/to/existing/workspace。"`). Spotted while adding the agent-sidebar strings in #62; kept out of that PR because it is unrelated.

## What changed

272 values across `common`, `chat`, `settings` and `sidebar` lose their trailing `。`, by one mechanical rule mirrored against the English source:

- strip when the English value for the same key has **no** terminal punctuation (`.`, `!`, `?`, `…`);
- also strip when the `。` doubled up after `...`, `…`, `:` or `：`.

Values whose English counterpart ends a sentence keep their `。` (e.g. `"フォルダの読み込みに失敗しました。"` stays where the English is `"Could not load folders."`).

Only value lines changed — no keys added or removed, JSON formatting byte-identical otherwise. `zh-CN`, `zh-TW` and `ko` do not have this artifact.

## Verification

- `scripts/check-locale-parity.test.mjs` — 2/2 pass
- `src/i18n/localeCoverage.test.ts`, `src/i18n/sidebarNavigationContract.test.ts` — 8/8 pass
- Re-scan after the rewrite: 0 remaining values matching the rule
