### PR TITLE
docs(agents): point sessions at the long-lived tmux dev stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@ job projection protocol). `scripts/` holds build/release/verify tooling.
   dependency files. Unknown local modifications must fail rather than be replaced.
 - Server binds loopback by default (fail-closed; it can run shell commands).
   `SERVER_PORT` defaults to 3001, Vite dev on 5173. Do not export `SERVER_PORT=0`.
+- A long-lived dev stack may already be running in tmux session `gajae-dev`
+  (check `tmux ls` and `lsof -nP -iTCP:3001 -iTCP:5173 -sTCP:LISTEN`; its log is
+  mirrored to `/tmp/gjc-dev/dev.log` and the address/operating notes live in
+  `/tmp/gjc-dev/README.md`). Reuse it rather than starting a second
+  `npm run dev` on the same ports. On the primary Mac it serves the tailnet:
+  `HOST=$(tailscale ip -4) GAJAE_ALLOW_UNAUTH_REMOTE=1 npm run dev`. That
+  override disables authentication on the bound address, so never combine it
+  with a bind that is reachable outside the tailnet.
 - Tauri builds choke on `CI=1`: use `env -u CI npm run tauri -- build`.
 - A release-profile macOS build refuses to guess its updater mode: set
   `GJC_UPDATE_MODE=disabled` for ad-hoc/manual bundles, or the full production


### PR DESCRIPTION
## Why

The dev stack on the primary Mac now runs in tmux session `gajae-dev` (bound to the Tailscale IP) so it outlives whichever agent session started it. Other sessions need to know it exists, or they will start a second `npm run dev` and collide on :3001/:5173.

## What changed

One bullet in the `AGENTS.md` Environment section: check `tmux ls` / port ownership first, where the log and operating notes are (`/tmp/gjc-dev/dev.log`, `/tmp/gjc-dev/README.md`), the tailnet bind form (`HOST=$(tailscale ip -4) GAJAE_ALLOW_UNAUTH_REMOTE=1 npm run dev`), and the warning that the override disables authentication on the bound address.

The literal IP and the full runbook stay in `/tmp/gjc-dev/README.md` on the machine (same lifetime as the tmux server), not in the repo.