### PR TITLE
feat(sidebar): add compact work and task context

### DIFF
--- a/src/components/agent-sidebar/view/AgentSidebar.dom.bun.test.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebar.dom.bun.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, test } from 'node:test';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { createElement } from 'react';
 
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
 import { AGENT_SIDEBAR_STORAGE_KEY, DEFAULT_AGENT_SIDEBAR_WIDTH } from '../agentSidebarState';
 import { useAgentSidebar } from '../hooks/useAgentSidebar';
 
@@ -20,7 +21,19 @@ function persisted(): { open: boolean; width: number } {
   return JSON.parse(localStorage.getItem(AGENT_SIDEBAR_STORAGE_KEY) ?? 'null');
 }
 
-function Harness({ mobile = false }: { mobile?: boolean }) {
+/** A session store whose window can carry a structured todo_write result, like the chat's. */
+function createStore(phases: unknown[] = []) {
+  const messages: NormalizedMessage[] = phases.length
+    ? [{
+        id: 'todo-1', sessionId: 'session-1', provider: 'gjc', kind: 'tool_use',
+        timestamp: '2026-09-12T00:00:00Z', toolId: 'todo-1', toolName: 'todo_write',
+        toolInput: { ops: [] }, toolResult: { content: 'Updated', isError: false, toolUseResult: { phases } },
+      } as unknown as NormalizedMessage]
+    : [];
+  return { getMessages: () => messages, subscribeSession: () => () => {} } as unknown as SessionStore;
+}
+
+function Harness({ mobile = false, sessionStore = createStore() }: { mobile?: boolean; sessionStore?: SessionStore }) {
   const sidebar = useAgentSidebar();
   return createElement('div', null,
     createElement('button', { onClick: sidebar.open }, 'Open'),
@@ -32,6 +45,7 @@ function Harness({ mobile = false }: { mobile?: boolean }) {
         projectPath: '/work/alpha',
         sessionId: 'session-1',
         onClose: sidebar.close,
+        sessionStore,
       })
       : null,
   );
@@ -119,6 +133,30 @@ test('the desktop lane sets no inline width and carries no rail chrome', async (
   assert.doesNotMatch(element.className, /border-l|bg-sidebar|inset-y-0/);
   assert.match(element.className, /\bw-64\b.*\blg:w-80\b/);
   await within(element).findByText('main');
+});
+
+test('the WORK block appears under the environment in the same card when the session has todos', async () => {
+  seed({ open: true, width: DEFAULT_AGENT_SIDEBAR_WIDTH });
+  render(createElement(Harness, {
+    sessionStore: createStore([{ name: '', tasks: [
+      { content: 'Inspect current code', status: 'completed', notes: [] },
+      { content: 'Implement sidebar work block', status: 'in_progress', notes: [] },
+    ] }]),
+  }));
+
+  const card = within(lane()).getByRole('region', { name: 'agentSidebar.environment.title' }).parentElement!;
+  const work = within(card).getByRole('region', { name: 'agentSidebar.work.title' });
+  assert.match(work.className, /border-t/);
+  assert.ok(within(work).getByText('Implement sidebar work block'));
+  assert.equal(within(work).queryByText('agentSidebar.work.working'), null);
+});
+
+test('an idle session without todos leaves the card to the environment alone', async () => {
+  seed({ open: true, width: DEFAULT_AGENT_SIDEBAR_WIDTH });
+  render(createElement(Harness));
+
+  await within(lane()).findByText('main');
+  assert.equal(within(lane()).queryByRole('region', { name: 'agentSidebar.work.title' }), null);
 });
 
 test('the mobile drawer is dismissed by its backdrop and never touches the saved width', async () => {

--- a/src/components/agent-sidebar/view/AgentSidebar.test.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebar.test.tsx
@@ -4,7 +4,21 @@ import test from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+
 import AgentSidebar, { type AgentSidebarProps } from './AgentSidebar';
+
+/** The session-store surface the sidebar reads: enough for the todo fold, no transport. */
+function storeWith(phases: unknown[] = []): SessionStore {
+  const messages: NormalizedMessage[] = phases.length
+    ? [{
+        id: 'todo-1', sessionId: 'session-1', provider: 'gjc', kind: 'tool_use',
+        timestamp: '2026-09-12T00:00:00Z', toolId: 'todo-1', toolName: 'todo_write',
+        toolInput: { ops: [] }, toolResult: { content: 'Updated', isError: false, toolUseResult: { phases } },
+      } as unknown as NormalizedMessage]
+    : [];
+  return { getMessages: () => messages, subscribeSession: () => () => {} } as unknown as SessionStore;
+}
 
 function render(overrides: Partial<AgentSidebarProps> = {}): string {
   const props: AgentSidebarProps = {
@@ -13,6 +27,7 @@ function render(overrides: Partial<AgentSidebarProps> = {}): string {
     projectPath: '/work/alpha',
     sessionId: 'session-1',
     onClose: () => undefined,
+    sessionStore: storeWith(),
     ...overrides,
   };
 
@@ -23,9 +38,23 @@ test('the desktop surface is a labelled lane holding the environment in one comp
   const html = render();
 
   assert.match(html, /<aside aria-label="agentSidebar\.title"/);
-  // The card is the only thing in the lane, and the environment is the only thing in the card.
+  // The card is the only thing in the lane; with no work to show, the
+  // environment is the only thing in the card.
   assert.match(html, /<aside[^>]*><div class="rounded-xl border border-border\/60 bg-card\/50"><section aria-labelledby="agent-sidebar-environment"/);
   assert.match(html, /<\/section><\/div><\/aside>$/);
+});
+
+test('the WORK block joins the environment in the same card when the session has a todo list', () => {
+  const html = render({ sessionStore: storeWith([{ name: '', tasks: [{ content: 'Run tests', status: 'in_progress', notes: [] }] }]) });
+
+  // One card, two sections: WORK sits directly under Environment, divided by the card's own border.
+  assert.match(html, /<\/section><section aria-labelledby="agent-sidebar-work"/);
+  assert.match(html, /<h3 id="agent-sidebar-work"[^>]*>agentSidebar\.work\.title<\/h3>/);
+  assert.match(html, /Run tests/);
+  assert.match(html, /<\/section><\/div><\/aside>$/);
+  // The surface still has exactly one control: the environment's refresh.
+  const buttons = html.match(/<button/g) ?? [];
+  assert.equal(buttons.length, 1);
 });
 
 test('the desktop surface has no header of its own: Environment is the top-level heading', () => {

--- a/src/components/agent-sidebar/view/AgentSidebar.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebar.tsx
@@ -1,12 +1,17 @@
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import type { SessionStore } from '../../../stores/useSessionStore';
+
 import AgentSidebarEnvironment, { type AgentSidebarEnvironmentProps } from './AgentSidebarEnvironment';
+import AgentSidebarWork from './AgentSidebarWork';
 
 export type AgentSidebarProps = AgentSidebarEnvironmentProps & {
   isMobile: boolean;
   /** Dismisses the mobile drawer; desktop is shown and hidden from the header toggle. */
   onClose: () => void;
+  /** The chat's session store; the WORK block reads the todo fold from the window the transcript uses. */
+  sessionStore: SessionStore;
 };
 
 /**
@@ -14,17 +19,19 @@ export type AgentSidebarProps = AgentSidebarEnvironmentProps & {
  *
  * On desktop it is a context lane beside the conversation: a fixed-width
  * column with no border, background, header or resize handle of its own,
- * holding one compact card that is only as tall as the Environment summary.
+ * holding one compact card: the Environment summary, and under it a WORK
+ * block that appears only when the session has a todo list or is running.
  * The rest of the lane stays empty on purpose — the surface is workspace
  * context next to the chat, not another tool sidebar. The header's rail
  * toggle is the way to show and hide it.
  *
  * On mobile it is the same drawer as before: a backdrop, a titled header with
- * the close control, and the summary underneath.
+ * the close control, and the same blocks underneath.
  *
  * There is intentionally no tab strip and no expanded mode, and the shell
  * keeps no domain data of its own: the Environment block reads git and the
- * runtime through their existing hooks.
+ * runtime through their existing hooks, and the WORK block projects the
+ * session's todos and run state through theirs.
  */
 export default function AgentSidebar({
   isMobile,
@@ -32,10 +39,12 @@ export default function AgentSidebar({
   projectPath,
   sessionId,
   onClose,
+  sessionStore,
 }: AgentSidebarProps) {
   const { t } = useTranslation();
 
   const environment = <AgentSidebarEnvironment projectId={projectId} projectPath={projectPath} sessionId={sessionId} />;
+  const work = <AgentSidebarWork sessionId={sessionId} sessionStore={sessionStore} />;
 
   if (isMobile) {
     return (
@@ -62,7 +71,7 @@ export default function AgentSidebar({
               <X className="h-3.5 w-3.5" />
             </button>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">{environment}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto">{environment}{work}</div>
         </aside>
       </>
     );
@@ -74,7 +83,7 @@ export default function AgentSidebar({
       aria-label={t('agentSidebar.title')}
       className="flex w-64 shrink-0 flex-col overflow-y-auto py-3 pr-4 pl-2 lg:w-80"
     >
-      <div className="rounded-xl border border-border/60 bg-card/50">{environment}</div>
+      <div className="rounded-xl border border-border/60 bg-card/50">{environment}{work}</div>
     </aside>
   );
 }

--- a/src/components/agent-sidebar/view/AgentSidebarWork.dom.bun.test.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarWork.dom.bun.test.tsx
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { act, cleanup, render, screen, within } from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import { type ReactNode } from 'react';
+
+import { SessionStatusProvider, usePublishSessionStatus } from '../../../contexts/SessionStatusContext';
+import { EMPTY_SESSION_STATUS, type SessionStatusSnapshot } from '../../../contexts/sessionStatusSnapshot';
+import enCommon from '../../../i18n/locales/en/common.json';
+import koCommon from '../../../i18n/locales/ko/common.json';
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+import type { SessionTodoPhase } from '../../chat/hooks/useSessionTodos';
+
+import AgentSidebarWork from './AgentSidebarWork';
+
+afterEach(cleanup);
+
+const plan: SessionTodoPhase[] = [{
+  name: 'Implementation',
+  tasks: [
+    { content: 'Inspect current code', status: 'completed', notes: [] },
+    { content: 'Implement sidebar work block', status: 'in_progress', notes: ['Keep it compact.'] },
+    { content: 'Run tests', status: 'pending', notes: [] },
+    { content: 'Support a per-phase fold', status: 'abandoned', notes: [] },
+  ],
+}];
+
+function createStore() {
+  const messages = new Map<string, NormalizedMessage[]>();
+  const listeners = new Map<string, Set<() => void>>();
+  const empty: NormalizedMessage[] = [];
+  let sequence = 0;
+  const store = {
+    getMessages: (id: string) => messages.get(id) ?? empty,
+    subscribeSession: (id: string, listener: () => void) => {
+      const subscriptions = listeners.get(id) ?? new Set();
+      listeners.set(id, subscriptions);
+      subscriptions.add(listener);
+      return () => { subscriptions.delete(listener); };
+    },
+  } satisfies Pick<SessionStore, 'getMessages' | 'subscribeSession'>;
+  return {
+    store: store as SessionStore,
+    listeners: (id: string) => listeners.get(id)?.size ?? 0,
+    /** Publishes phases the way the runtime does: a structured todo_write result in the message window. */
+    publish: (id: string, phases: SessionTodoPhase[]) => {
+      sequence += 1;
+      messages.set(id, [{
+        id: `todo-${sequence}`, sessionId: id, provider: 'gjc', kind: 'tool_use',
+        timestamp: '2026-09-12T00:00:00Z', toolId: `todo-${sequence}`, toolName: 'todo_write',
+        toolInput: { ops: [] }, toolResult: { content: 'Updated', isError: false, toolUseResult: { phases } },
+      } as unknown as NormalizedMessage]);
+      listeners.get(id)?.forEach((listener) => listener());
+    },
+  };
+}
+
+function running(sessionId: string): SessionStatusSnapshot {
+  return { ...EMPTY_SESSION_STATUS, sessionId, activity: { running: true, statusText: null, queued: 0 } };
+}
+
+function Publisher({ snapshot, children }: { snapshot: SessionStatusSnapshot; children?: ReactNode }) {
+  usePublishSessionStatus(snapshot);
+  return children;
+}
+
+async function setup(lng = 'en') {
+  const i18n = createInstance();
+  await i18n.init({ lng, fallbackLng: 'en', resources: { en: { translation: enCommon }, ko: { translation: koCommon } }, interpolation: { escapeValue: false } });
+  const state = createStore();
+  const ui = (sessionId: string | undefined, snapshot: SessionStatusSnapshot = EMPTY_SESSION_STATUS) => (
+    <I18nextProvider i18n={i18n}>
+      <SessionStatusProvider>
+        <Publisher snapshot={snapshot}>
+          <AgentSidebarWork sessionId={sessionId} sessionStore={state.store} />
+        </Publisher>
+      </SessionStatusProvider>
+    </I18nextProvider>
+  );
+  return { ...state, ui };
+}
+
+const section = () => screen.getByRole('region', { name: 'Work' });
+
+test('an idle session without a todo list renders no WORK block at all', async () => {
+  const state = await setup();
+  const view = render(state.ui('session-1'));
+  assert.equal(view.container.innerHTML, '');
+  // No "Idle" placeholder either: absence is the idle state.
+  assert.equal(screen.queryByText(/idle/i), null);
+});
+
+test('a running session without a todo list shows the minimal Working row only', async () => {
+  const state = await setup();
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  assert.ok(within(region).getByText('Working'));
+  assert.equal(within(region).queryByRole('list'), null);
+  assert.equal(within(region).queryByText('Idle'), null);
+  // The row carries the app's in-progress convention: the spinning primary icon.
+  const icon = within(region).getByText('Working').previousElementSibling!;
+  assert.match(icon.getAttribute('class')!, /animate-spin/);
+  assert.match(icon.getAttribute('class')!, /text-primary/);
+});
+
+test('a session whose published activity belongs to another conversation is not running', async () => {
+  const state = await setup();
+  const view = render(state.ui('session-1', running('session-2')));
+  assert.equal(view.container.innerHTML, '');
+});
+
+test('a running session with todos lists the tasks and never adds a redundant Working row', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  const rows = within(region).getAllByRole('listitem');
+  assert.equal(rows.length, 4);
+  assert.match(rows[0].textContent!, /Inspect current code/);
+  assert.match(rows[1].textContent!, /Implement sidebar work block/);
+  assert.match(rows[2].textContent!, /Run tests/);
+  assert.equal(within(region).queryByText('Working'), null);
+});
+
+test('an idle session with todos keeps the task rows visible', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  render(state.ui('session-1'));
+
+  const rows = within(section()).getAllByRole('listitem');
+  assert.equal(rows.length, 4);
+  assert.equal(within(section()).queryByText('Working'), null);
+});
+
+test('structured todo_write phases render with their phase names, statuses and non-color labels', async () => {
+  const state = await setup();
+  state.publish('session-1', [
+    { name: 'Audit', tasks: [{ content: 'Read the audit', status: 'completed', notes: [] }] },
+    { name: '', tasks: [{ content: 'Unnamed phase task', status: 'pending', notes: [] }] },
+  ]);
+  render(state.ui('session-1'));
+
+  const region = section();
+  assert.ok(within(region).getByText('Audit'));
+  const rows = within(region).getAllByRole('listitem');
+  assert.equal(rows.length, 2);
+  assert.match(rows[0].textContent!, /Completed:.*Read the audit/);
+  assert.match(rows[1].textContent!, /Pending:.*Unnamed phase task/);
+});
+
+test('the in-progress task is visually distinguishable from the quiet rows', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  render(state.ui('session-1'));
+
+  const current = within(section()).getByText('Implement sidebar work block').closest('li')!;
+  assert.match(current.textContent!, /In progress:/);
+  assert.match(current.querySelector('svg')!.getAttribute('class')!, /animate-spin/);
+  assert.match(current.querySelector('svg')!.getAttribute('class')!, /text-primary/);
+  assert.doesNotMatch(current.querySelector('span:last-child')!.getAttribute('class')!, /line-through/);
+});
+
+test('completed rows are subdued and struck; pending rows stay quiet and unstruck', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  render(state.ui('session-1'));
+
+  const completed = within(section()).getByText('Inspect current code').closest('li')!;
+  assert.match(completed.querySelector('span:last-child')!.getAttribute('class')!, /line-through/);
+  assert.match(completed.querySelector('span:last-child')!.getAttribute('class')!, /text-muted-foreground/);
+
+  const pending = within(section()).getByText('Run tests').closest('li')!;
+  assert.doesNotMatch(pending.querySelector('span:last-child')!.getAttribute('class')!, /line-through/);
+  assert.match(pending.querySelector('svg')!.getAttribute('class')!, /text-muted-foreground\/60/);
+});
+
+test('an abandoned task uses the subdued abandoned convention', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  render(state.ui('session-1'));
+
+  const abandoned = within(section()).getByText('Support a per-phase fold').closest('li')!;
+  assert.match(abandoned.textContent!, /Abandoned:/);
+  assert.match(abandoned.querySelector('span:last-child')!.getAttribute('class')!, /line-through/);
+});
+
+test('an all-completed snapshot stays truthful: every row completed, nothing invented', async () => {
+  const state = await setup();
+  state.publish('session-1', [{ name: '', tasks: [
+    { content: 'Inspect current code', status: 'completed', notes: [] },
+    { content: 'Implement sidebar work block', status: 'completed', notes: [] },
+  ] }]);
+  // Even while the run continues: the list is the projection of record.
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  const rows = within(region).getAllByRole('listitem');
+  assert.equal(rows.length, 2);
+  rows.forEach((row) => assert.match(row.textContent!, /Completed:/));
+  assert.equal(within(region).queryByText('Working'), null);
+  assert.equal(within(region).queryByText(/In progress:/), null);
+});
+
+test('long task text truncates to one compact line and keeps the full value on the row', async () => {
+  const state = await setup();
+  const longTask = `${'Inspect the very long path/'.repeat(20)}file.ts`;
+  state.publish('session-1', [{ name: '', tasks: [{ content: longTask, status: 'in_progress', notes: [] }] }]);
+  render(state.ui('session-1'));
+
+  const row = within(section()).getByText(longTask).closest('li')!;
+  assert.equal(row.getAttribute('title'), longTask);
+  assert.match(row.querySelector('span:last-child')!.getAttribute('class')!, /truncate/);
+  // The notes stay in the chat's task card; the compact block lists tasks only.
+  assert.equal(within(section()).queryByText('Keep it compact.'), null);
+});
+
+test('the block stays a projection: no controls, no guessed state, no agent, IRC or browser surface', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  assert.equal(within(region).queryByRole('button'), null);
+  assert.equal(within(region).queryByRole('link'), null);
+  assert.equal(within(region).getAllByRole('heading').length, 1);
+  // No status is guessed beyond the task statuses the runtime wrote.
+  assert.equal(within(region).queryByText(/blocked|stalled|waiting/i), null);
+  assert.doesNotMatch(region.textContent!, /agent|subagent|irc|aside|browser|tab|screenshot/i);
+});
+
+test('the list follows the session window live and unsubscribes when the session goes away', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  const view = render(state.ui('session-1'));
+
+  const next: SessionTodoPhase[] = [{ name: '', tasks: [
+    { content: 'Implement sidebar work block', status: 'completed', notes: [] },
+    { content: 'Run tests', status: 'in_progress', notes: [] },
+  ] }];
+  act(() => state.publish('session-1', next));
+  assert.ok(within(section()).getByText('Run tests'));
+  assert.equal(within(section()).queryByText('Inspect current code'), null);
+
+  view.rerender(state.ui(undefined));
+  assert.equal(view.container.innerHTML, '');
+  assert.equal(state.listeners('session-1'), 0);
+});
+
+test('Korean headings and status labels come from the same locale data as the chat card', async () => {
+  const state = await setup('ko');
+  state.publish('session-1', [{ name: '구현', tasks: [{ content: '블록 구현', status: 'in_progress', notes: [] }] }]);
+  render(state.ui('session-1'));
+
+  const region = screen.getByRole('region', { name: '작업' });
+  assert.ok(within(region).getByText('구현'));
+  assert.match(within(region).getByText('블록 구현').closest('li')!.textContent!, /진행 중:/);
+  assert.equal(within(region).queryByText('작업 중'), null);
+});

--- a/src/components/agent-sidebar/view/AgentSidebarWork.test.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarWork.test.tsx
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+
+import AgentSidebarWork from './AgentSidebarWork';
+
+function storeWith(phases: unknown[]): SessionStore {
+  const messages: NormalizedMessage[] = phases.length
+    ? [{
+        id: 'todo-1', sessionId: 'session-1', provider: 'gjc', kind: 'tool_use',
+        timestamp: '2026-09-12T00:00:00Z', toolId: 'todo-1', toolName: 'todo_write',
+        toolInput: { ops: [] }, toolResult: { content: 'Updated', isError: false, toolUseResult: { phases } },
+      } as unknown as NormalizedMessage]
+    : [];
+  return { getMessages: () => messages, subscribeSession: () => () => {} } as unknown as SessionStore;
+}
+
+function render(store: SessionStore, sessionId = 'session-1'): string {
+  return renderToStaticMarkup(createElement(AgentSidebarWork, { sessionId, sessionStore: store }));
+}
+
+test('a session without a todo list and without published activity renders nothing', () => {
+  assert.equal(render(storeWith([])), '');
+});
+
+test('the task rows are one compact list per phase with the shared status icon language', () => {
+  const html = render(storeWith([
+    {
+      name: 'Implementation',
+      tasks: [
+        { content: 'Inspect current code', status: 'completed', notes: [] },
+        { content: 'Implement sidebar work block', status: 'in_progress', notes: [] },
+        { content: 'Run tests', status: 'pending', notes: [] },
+      ],
+    },
+  ]));
+
+  assert.match(html, /^<section aria-labelledby="agent-sidebar-work"/);
+  assert.match(html, /<h3 id="agent-sidebar-work"[^>]*>agentSidebar\.work\.title<\/h3>/);
+  // Phase heading, then one list item per task in the runtime's order.
+  assert.match(html, /Implementation<\/p>/);
+  const rows = html.match(/<li /g) ?? [];
+  assert.equal(rows.length, 3);
+  assert.match(html, /Inspect current code/);
+  assert.match(html, /Implement sidebar work block/);
+  assert.match(html, /Run tests/);
+  // The statuses are readable without color, and the icons are the same ones the chat card uses.
+  assert.match(html, /workspace\.tasks\.status\.completed: /);
+  assert.match(html, /workspace\.tasks\.status\.in_progress: /);
+  assert.match(html, /workspace\.tasks\.status\.pending: /);
+  assert.match(html, /animate-spin/);
+  assert.match(html, /line-through/);
+  // Long text truncates inside the row; the full value stays on the title.
+  assert.match(html, /title="Inspect current code"/);
+  assert.match(html, /truncate/);
+  // No controls: the block is a report.
+  assert.doesNotMatch(html, /<button|<a /);
+});

--- a/src/components/agent-sidebar/view/AgentSidebarWork.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarWork.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from 'react-i18next';
+
+import { useSessionStatus } from '../../../contexts/SessionStatusContext';
+import type { SessionStore } from '../../../stores/useSessionStore';
+import { cn } from '../../../utils/cn';
+import { useSessionTodos } from '../../chat/hooks/useSessionTodos';
+import { TODO_STATUS_ICON } from '../../chat/view/todoStatusIcon';
+
+const { Icon: WorkingIcon, className: workingIconClassName } = TODO_STATUS_ICON.in_progress;
+
+export type AgentSidebarWorkProps = {
+  sessionId?: string;
+  /** The chat's session store; the todo fold reads the same message window the transcript uses. */
+  sessionStore: SessionStore;
+};
+
+/**
+ * The compact "what is the agent doing" block under the Environment summary.
+ *
+ * It is a projection, not a second source of truth: the tasks are the same
+ * `todo_write` fold the chat's task card renders, and "running" is the
+ * session-status activity the chat publishes for this exact session. Nothing
+ * is inferred from tool traffic, elapsed time or transcript prose, and the
+ * block owns no state of its own.
+ *
+ * Visibility: tasks render whenever the session has a todo list, even
+ * all-completed and even while idle; a run without a list falls back to one
+ * "Working" row; a session with neither is silent, so an idle session leaves
+ * the Environment summary alone.
+ */
+export default function AgentSidebarWork({ sessionId, sessionStore }: AgentSidebarWorkProps) {
+  const { t } = useTranslation();
+  const status = useSessionStatus();
+  const phases = useSessionTodos(sessionStore, sessionId, Boolean(sessionId));
+  const hasTasks = phases.some((phase) => phase.tasks.length > 0);
+  // Only the published activity of this very session counts; a snapshot left
+  // over from another conversation must never read as this one running.
+  const running = Boolean(sessionId) && status.sessionId === sessionId && status.activity.running;
+
+  if (!hasTasks && !running) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby="agent-sidebar-work" className="border-t border-border/50 px-1 pt-1 pb-2 text-xs">
+      <h3 id="agent-sidebar-work" className="mb-1 px-2 text-[10px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+        {t('agentSidebar.work.title')}
+      </h3>
+      {hasTasks ? (
+        phases.filter((phase) => phase.tasks.length > 0).map((phase, phaseIndex) => (
+          <div key={`${phaseIndex}:${phase.name}`}>
+            {phase.name && (
+              <p className="px-2 pt-1 pb-0.5 text-[10px] font-medium tracking-wide text-muted-foreground/70">{phase.name}</p>
+            )}
+            <ul>
+              {phase.tasks.map((task, taskIndex) => {
+                const { Icon, className } = TODO_STATUS_ICON[task.status];
+                return (
+                  <li key={`${taskIndex}:${task.content}`} className="flex items-start gap-2 px-2 py-1" title={task.content}>
+                    <Icon className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', className)} aria-hidden />
+                    <span className="sr-only">{t(`workspace.tasks.status.${task.status}`)}: </span>
+                    <span className={cn('min-w-0 flex-1 truncate text-foreground',
+                      (task.status === 'completed' || task.status === 'abandoned') && 'text-muted-foreground line-through decoration-muted-foreground/50')}
+                    >
+                      {task.content}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))
+      ) : (
+        // The list is the projection of record; a run without one still owes
+        // the lane one line, and never a guess at what it is doing.
+        <div className="flex items-center gap-2 px-2 py-1.5">
+          <WorkingIcon className={cn('h-3.5 w-3.5 shrink-0', workingIconClassName)} aria-hidden />
+          <span className="min-w-0 flex-1 truncate text-foreground">{t('agentSidebar.work.working')}</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/chat/view/ChatTasksPanel.tsx
+++ b/src/components/chat/view/ChatTasksPanel.tsx
@@ -1,18 +1,14 @@
 import { useId, useState } from 'react';
-import { ChevronDown, CircleCheck, CircleDashed, CircleX, ListTodo, LoaderCircle, type LucideIcon } from 'lucide-react';
+import { ChevronDown, ListTodo } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../../shared/view/ui/Collapsible';
 import type { SessionStore } from '../../../stores/useSessionStore';
 import { cn } from '../../../utils/cn';
-import { useSessionTodos, type SessionTodoPhase, type SessionTodoStatus } from '../hooks/useSessionTodos';
+import { useSessionTodos, type SessionTodoPhase } from '../hooks/useSessionTodos';
 
-const STATUS_ICON: Record<SessionTodoStatus, { Icon: LucideIcon; className: string }> = {
-  pending: { Icon: CircleDashed, className: 'text-muted-foreground/60' },
-  in_progress: { Icon: LoaderCircle, className: 'animate-spin text-primary' },
-  completed: { Icon: CircleCheck, className: 'text-muted-foreground' },
-  abandoned: { Icon: CircleX, className: 'text-muted-foreground/50' },
-};
+import { TODO_STATUS_ICON } from './todoStatusIcon';
+
 
 function TaskListDisclosure({ phases }: { phases: SessionTodoPhase[] }) {
   const { t } = useTranslation();
@@ -48,7 +44,7 @@ function TaskListDisclosure({ phases }: { phases: SessionTodoPhase[] }) {
                 {phase.name && <h3 className="text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">{phase.name}</h3>}
                 <ul className="space-y-0.5">
                   {phase.tasks.map((task, taskIndex) => {
-                    const { Icon, className } = STATUS_ICON[task.status];
+                    const { Icon, className } = TODO_STATUS_ICON[task.status];
                     return (
                       <li key={`${taskIndex}:${task.content}`} className="rounded-md px-1 py-1.5">
                         <div className="flex items-start gap-2">

--- a/src/components/chat/view/todoStatusIcon.ts
+++ b/src/components/chat/view/todoStatusIcon.ts
@@ -1,0 +1,16 @@
+import { CircleCheck, CircleDashed, CircleX, LoaderCircle, type LucideIcon } from 'lucide-react';
+
+import type { SessionTodoStatus } from '../hooks/useSessionTodos';
+
+/**
+ * The one icon language for todo statuses, shared by the chat's task card and
+ * the agent sidebar's WORK block so a task reads the same in both places.
+ * The map carries color and motion only; each surface sizes and aligns the
+ * icon itself.
+ */
+export const TODO_STATUS_ICON: Record<SessionTodoStatus, { Icon: LucideIcon; className: string }> = {
+  pending: { Icon: CircleDashed, className: 'text-muted-foreground/60' },
+  in_progress: { Icon: LoaderCircle, className: 'animate-spin text-primary' },
+  completed: { Icon: CircleCheck, className: 'text-muted-foreground' },
+  abandoned: { Icon: CircleX, className: 'text-muted-foreground/50' },
+};

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -201,6 +201,7 @@ function MainContent({
             projectId: selectedProject.projectId,
             projectPath: executionPath,
             sessionId: selectedSession?.id,
+            sessionStore,
             onClose: agentSidebar.close,
           }}
         />

--- a/src/components/main-content/view/MainContentRightRail.dom.bun.test.tsx
+++ b/src/components/main-content/view/MainContentRightRail.dom.bun.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, test } from 'node:test';
 import { cleanup, render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 
-import type { SessionStore } from '../../../stores/useSessionStore';
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
 import type { AgentSidebarProps } from '../../agent-sidebar/view/AgentSidebar';
 import type { WorkspacePanelProps } from '../../workspace/view/WorkspacePanel';
 
@@ -25,12 +25,17 @@ const workspace: WorkspacePanelProps = {
   onClose: () => undefined,
 };
 
+const noMessages: NormalizedMessage[] = [];
+
 const agentSidebar: AgentSidebarProps = {
   isMobile: false,
   projectId: 'project-alpha',
   projectPath: '/work/alpha',
   sessionId: 'session-alpha',
   onClose: () => undefined,
+  // The WORK block reads the todo fold through the store's message window; the
+  // empty window must be one stable reference, as the real store guarantees.
+  sessionStore: { getMessages: () => noMessages, subscribeSession: () => () => {} } as unknown as SessionStore,
 };
 
 const props = (overrides: Partial<MainContentRightRailProps>): MainContentRightRailProps => ({
@@ -67,6 +72,7 @@ test('with the experiment off the rail is the legacy workspace panel alone', asy
   // The legacy panel keeps its own Status tab sections; the Environment block is the new rail's.
   await screen.findByText('workspace.statusTab.git');
   assert.equal(screen.queryByRole('region', { name: 'agentSidebar.environment.title' }), null);
+  assert.equal(screen.queryByRole('region', { name: 'agentSidebar.work.title' }), null);
 });
 
 test('with the experiment on the rail is the compact context panel alone, with the environment as its body', async () => {

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -199,6 +199,10 @@
       "refresh": "Git-Status neu laden",
       "notARepository": "Dieser Ordner ist kein Git-Repository",
       "gitUnavailable": "Git-Status konnte nicht gelesen werden"
+    },
+    "work": {
+      "title": "Arbeit",
+      "working": "Läuft"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -199,6 +199,10 @@
       "refresh": "Reload Git status",
       "notARepository": "This folder is not a Git repository",
       "gitUnavailable": "Could not read Git status"
+    },
+    "work": {
+      "title": "Work",
+      "working": "Working"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -199,6 +199,10 @@
       "refresh": "Recharger l'état Git",
       "notARepository": "Ce dossier n'est pas un dépôt Git",
       "gitUnavailable": "Impossible de lire l'état Git"
+    },
+    "work": {
+      "title": "Travail",
+      "working": "En cours"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -199,6 +199,10 @@
       "refresh": "Ricarica lo stato Git",
       "notARepository": "Questa cartella non è un repository Git",
       "gitUnavailable": "Impossibile leggere lo stato Git"
+    },
+    "work": {
+      "title": "Lavoro",
+      "working": "In corso"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -197,6 +197,10 @@
       "refresh": "Git ステータスを再読み込み",
       "notARepository": "このフォルダーは Git リポジトリではありません",
       "gitUnavailable": "Git ステータスを読み取れません"
+    },
+    "work": {
+      "title": "作業",
+      "working": "実行中"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -197,6 +197,10 @@
       "refresh": "Git 상태 다시 로드",
       "notARepository": "이 폴더는 Git 저장소가 아닙니다",
       "gitUnavailable": "Git 상태를 읽을 수 없습니다"
+    },
+    "work": {
+      "title": "작업",
+      "working": "작업 중"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -205,6 +205,10 @@
       "refresh": "Обновить статус Git",
       "notARepository": "Эта папка не является репозиторием Git",
       "gitUnavailable": "Не удалось прочитать статус Git"
+    },
+    "work": {
+      "title": "Работа",
+      "working": "Выполняется"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -199,6 +199,10 @@
       "refresh": "Git durumunu yeniden yükle",
       "notARepository": "Bu klasör bir Git deposu değil",
       "gitUnavailable": "Git durumu okunamadı"
+    },
+    "work": {
+      "title": "İş",
+      "working": "Çalışıyor"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -197,6 +197,10 @@
       "refresh": "刷新 Git 状态",
       "notARepository": "此文件夹不是 Git 仓库",
       "gitUnavailable": "无法读取 Git 状态"
+    },
+    "work": {
+      "title": "工作",
+      "working": "正在执行"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -197,6 +197,10 @@
       "refresh": "重新載入 Git 狀態",
       "notARepository": "此資料夾不是 Git 儲存庫",
       "gitUnavailable": "無法讀取 Git 狀態"
+    },
+    "work": {
+      "title": "工作",
+      "working": "運行中"
     }
   },
   "commandPalette": {


### PR DESCRIPTION
## What

Adds a compact `WORK` block underneath the Environment summary in the experimental right-side context panel (agent sidebar V2), answering *"What is the agent working on, and what remains?"*

```
ENVIRONMENT
Changes                     3
gajae-code-app
main

WORK
Implementation
✓ Inspect current code
● Implement sidebar work block
○ Run tests
```

## Visibility rules

1. **TODOs exist** → WORK renders the task rows (idle or running, all-completed included). No redundant `Working` row is added just because the run is active.
2. **No TODOs + session authoritatively running** → `WORK / ● Working` only.
3. **No TODOs + idle** → no WORK block at all (no `Idle` row).

## No new source of truth

- Tasks are the existing `todo_write` fold (`useSessionTodos` over the structured `details.phases` result) — no sidebar parser, no new store, no protocol event, no server persistence.
- "Running" is the chat-published session activity (`SessionStatusContext`), scoped to the selected session id; a snapshot from another conversation never counts. No inference from elapsed time, tool counts, status text or transcript prose.
- The sidebar receives the chat's `sessionStore` instance so the fold reads the same message window the transcript uses.
- The todo status icon language is extracted into `todoStatusIcon.ts` and shared by `ChatTasksPanel` and the WORK block (behavior-preserving); `ChatTasksPanel` itself is untouched otherwise.
- Long task text truncates to one compact row; the full value stays on the row `title`. Notes stay in the chat task card.

## Explicitly out of scope (deferred)

Agents/subagents, IRC, Aside/browser activity, approvals ("Action required"), WorkspacePanel removal, experiment cutover — flag default stays off.

## Tests

- `AgentSidebarWork.dom.bun.test.tsx`: idle absent / running Working-only / todos suppress Working / idle keeps rows / structured phases + sr-only labels / in_progress spinner / completed struck / pending quiet / abandoned / all-completed truthful / long text truncate+title / no guessed blocked state / no agent-IRC-aside-browser surface / other-session activity ignored / live fold updates + unsubscribe / ko locale.
- `AgentSidebarWork.test.tsx`: static markup shape.
- `AgentSidebar.*`, `MainContentRightRail.dom`: card composition under Environment, experiment-off keeps legacy WorkspacePanel (and no WORK region).
- `npm run verify` passes (audit, typecheck, check:core, tests, lint, identity, build).

## Manual validation (dev stack, live runs)

All nine cases verified in the browser against real runs: idle+no-todos (Environment only), running+no-todos (`WORK/Working` observed live mid-run, gone after), running+todos (rows, no extra Working row), idle+todos (rows remain), in-progress spinner distinguishable, all-completed snapshot truthful, 147-char task truncated with full `title`, mobile drawer, experiment off (legacy panel unchanged).