### PR TITLE
feat(sidebar): surface requests awaiting user input

### DIFF
--- a/src/components/agent-sidebar/view/AgentSidebar.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebar.tsx
@@ -5,6 +5,7 @@ import type { SessionStore } from '../../../stores/useSessionStore';
 
 import AgentSidebarEnvironment, { type AgentSidebarEnvironmentProps } from './AgentSidebarEnvironment';
 import AgentSidebarWork from './AgentSidebarWork';
+import AgentSidebarActionRequired from './AgentSidebarActionRequired';
 
 export type AgentSidebarProps = AgentSidebarEnvironmentProps & {
   isMobile: boolean;
@@ -20,7 +21,8 @@ export type AgentSidebarProps = AgentSidebarEnvironmentProps & {
  * On desktop it is a context lane beside the conversation: a fixed-width
  * column with no border, background, header or resize handle of its own,
  * holding one compact card: the Environment summary, and under it a WORK
- * block that appears only when the session has a todo list or is running.
+ * block that appears only when the session has a todo list or is running,
+ * followed by Action required while the session awaits an answer.
  * The rest of the lane stays empty on purpose — the surface is workspace
  * context next to the chat, not another tool sidebar. The header's rail
  * toggle is the way to show and hide it.
@@ -31,7 +33,8 @@ export type AgentSidebarProps = AgentSidebarEnvironmentProps & {
  * There is intentionally no tab strip and no expanded mode, and the shell
  * keeps no domain data of its own: the Environment block reads git and the
  * runtime through their existing hooks, and the WORK block projects the
- * session's todos and run state through theirs.
+ * session's todos and run state through theirs. Action required reads the
+ * existing attention store and links to the chat's original request cards.
  */
 export default function AgentSidebar({
   isMobile,
@@ -45,6 +48,7 @@ export default function AgentSidebar({
 
   const environment = <AgentSidebarEnvironment projectId={projectId} projectPath={projectPath} sessionId={sessionId} />;
   const work = <AgentSidebarWork sessionId={sessionId} sessionStore={sessionStore} />;
+  const actionRequired = <AgentSidebarActionRequired sessionId={sessionId} onRequestShown={isMobile ? onClose : undefined} />;
 
   if (isMobile) {
     return (
@@ -71,7 +75,7 @@ export default function AgentSidebar({
               <X className="h-3.5 w-3.5" />
             </button>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">{environment}{work}</div>
+          <div className="min-h-0 flex-1 overflow-y-auto">{environment}{work}{actionRequired}</div>
         </aside>
       </>
     );
@@ -83,7 +87,7 @@ export default function AgentSidebar({
       aria-label={t('agentSidebar.title')}
       className="flex w-64 shrink-0 flex-col overflow-y-auto py-3 pr-4 pl-2 lg:w-80"
     >
-      <div className="rounded-xl border border-border/60 bg-card/50">{environment}{work}</div>
+      <div className="rounded-xl border border-border/60 bg-card/50">{environment}{work}{actionRequired}</div>
     </aside>
   );
 }

--- a/src/components/agent-sidebar/view/AgentSidebarActionRequired.dom.bun.test.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarActionRequired.dom.bun.test.tsx
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import { useState, type ReactNode } from 'react';
+
+import type { ServerEvent } from '../../../contexts/WebSocketContext';
+import { observeOutgoingChatMessage, useSessionAttentionSync } from '../../../hooks/useSessionAttentionSync';
+import type { SessionActivityMap } from '../../../hooks/useSessionProtection';
+import enCommon from '../../../i18n/locales/en/common.json';
+import enChat from '../../../i18n/locales/en/chat.json';
+import koCommon from '../../../i18n/locales/ko/common.json';
+import { useSessionAttentionStore } from '../../../stores/useSessionAttentionStore';
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+import type { PendingPermissionRequest, PermissionDecision } from '../../chat/types/types';
+import PermissionRequestsBanner from '../../chat/view/PermissionRequestsBanner';
+
+import AgentSidebarActionRequired from './AgentSidebarActionRequired';
+import AgentSidebar from './AgentSidebar';
+
+const state = () => useSessionAttentionStore.getState();
+const emptyMessages: NormalizedMessage[] = [];
+const sessionStore = { getMessages: () => emptyMessages, subscribeSession: () => () => {} } as unknown as SessionStore;
+const originalScroll = HTMLElement.prototype.scrollIntoView;
+let scrolled: HTMLElement[] = [];
+
+beforeEach(() => {
+  useSessionAttentionStore.setState({ pendingInput: {}, outcomes: {}, lastViewedAt: {} });
+  scrolled = [];
+  HTMLElement.prototype.scrollIntoView = function () { scrolled.push(this); };
+});
+
+afterEach(() => {
+  cleanup();
+  useSessionAttentionStore.setState({ pendingInput: {}, outcomes: {}, lastViewedAt: {} });
+  localStorage.removeItem('session-attention-v1');
+  HTMLElement.prototype.scrollIntoView = originalScroll;
+});
+
+const approval = { requestId: 'sdk-permission:1', sessionId: 'one', toolName: 'bash', input: { command: 'npm test' } } satisfies PendingPermissionRequest;
+const question = {
+  requestId: 'sdk-ask:2', sessionId: 'one', toolName: 'ask',
+  input: { questions: [{ header: 'Target', question: 'Which target?', options: [{ label: 'Desktop', description: 'macOS' }, { label: 'Server', description: 'Self-host' }] }] },
+} satisfies PendingPermissionRequest;
+
+async function setup(lng = 'en') {
+  const i18n = createInstance();
+  await i18n.init({ lng, fallbackLng: 'en', resources: { en: { common: enCommon, chat: enChat }, ko: { common: koCommon } }, defaultNS: 'common', interpolation: { escapeValue: false } });
+  const listeners = new Set<(event: ServerEvent) => void>();
+  const subscribe = (listener: (event: ServerEvent) => void) => { listeners.add(listener); return () => { listeners.delete(listener); }; };
+  const processingSessions: SessionActivityMap = new Map();
+  const decisions: Array<[string | string[], PermissionDecision]> = [];
+  let shown = 0;
+  function Sync({ children }: { children: ReactNode }) {
+    useSessionAttentionSync({ subscribe, viewedSessionId: null, processingSessions });
+    return children;
+  }
+  function Harness({ sessionId = 'one', requests = [], mobile = false }: { sessionId?: string; requests?: PendingPermissionRequest[]; mobile?: boolean }) {
+    const [open, setOpen] = useState(true);
+    return <I18nextProvider i18n={i18n}><Sync>
+      {mobile
+        ? open && <AgentSidebar isMobile sessionId={sessionId} sessionStore={sessionStore} onClose={() => setOpen(false)} />
+        : <AgentSidebarActionRequired sessionId={sessionId} onRequestShown={() => { shown += 1; }} />}
+      <PermissionRequestsBanner pendingPermissionRequests={requests} handlePermissionDecision={(ids, decision) => { decisions.push([ids, decision]); }} />
+    </Sync></I18nextProvider>;
+  }
+  return {
+    Harness, decisions, shown: () => shown,
+    emit(event: ServerEvent) { act(() => { listeners.forEach((listener) => listener(event)); }); },
+  };
+}
+
+const region = () => screen.queryByRole('region', { name: 'Action required' });
+
+test('idle, running text, completed and failed outcomes never invent a request', async () => {
+  const { Harness, emit } = await setup();
+  render(<Harness />);
+  assert.equal(region(), null);
+  emit({ kind: 'status', sessionId: 'one', text: 'Waiting for permission' });
+  assert.equal(region(), null);
+  for (const success of [true, false]) {
+    emit({ kind: 'complete', sessionId: 'one', success });
+    assert.equal(region(), null);
+  }
+});
+
+for (const request of [approval, question, { ...question, toolName: 'AskUserQuestion' }, { ...approval, toolName: 'task' }]) {
+  test(`${request.toolName} request links to its existing card without deciding or focusing an input`, async () => {
+    const { Harness, emit, decisions, shown } = await setup();
+    render(<Harness requests={[request]} />);
+    emit({ kind: 'permission_request', ...request });
+    assert.ok(region());
+    const view = within(region()!).getByRole('button', { name: 'View request' });
+    view.focus();
+    fireEvent.click(view);
+    assert.equal(document.activeElement?.getAttribute('data-permission-request-id'), request.requestId);
+    assert.equal(scrolled.length, 1);
+    assert.equal(shown(), 1);
+    assert.deepEqual(decisions, []);
+    assert.notEqual(document.activeElement?.tagName, 'INPUT');
+    if (request.toolName === 'bash') {
+      fireEvent.click(screen.getByRole('button', { name: 'Allow' }));
+      assert.deepEqual(decisions, [[request.requestId, { allow: true }]]);
+    }
+  });
+}
+
+test('only the selected session can show Action required, including after navigation', async () => {
+  const { Harness, emit } = await setup();
+  const view = render(<Harness />);
+  emit({ kind: 'permission_request', sessionId: 'two', requestId: 'other', toolName: 'ask' });
+  assert.equal(region(), null);
+  view.rerender(<Harness sessionId="two" />);
+  assert.ok(region());
+  view.rerender(<Harness sessionId="one" />);
+  assert.equal(region(), null);
+  view.rerender(<Harness sessionId="" />);
+  assert.equal(region(), null);
+});
+
+test('poll-only input waits for restored request ids; chat_subscribed makes the original card reachable', async () => {
+  const { Harness, emit } = await setup();
+  render(<Harness requests={[question]} />);
+  act(() => { state().reconcilePendingInput('one', true); });
+  assert.ok(region());
+  assert.equal((screen.getByRole('button', { name: 'Loading request…' }) as HTMLButtonElement).disabled, true);
+  emit({ kind: 'chat_subscribed', sessionId: 'one', pendingPermissions: [question] });
+  fireEvent.click(screen.getByRole('button', { name: 'View request' }));
+  assert.equal(document.activeElement?.getAttribute('data-permission-request-id'), question.requestId);
+});
+
+test('answer, cancellation, completion and protocol failure clear the section through existing events', async () => {
+  const { Harness, emit } = await setup();
+  render(<Harness />);
+  for (const end of [
+    () => act(() => { observeOutgoingChatMessage({ type: 'chat.permission-response', requestId: approval.requestId }); }),
+    () => emit({ kind: 'permission_cancelled', ...approval }),
+    () => emit({ kind: 'complete', sessionId: 'one', success: true }),
+    () => emit({ kind: 'complete', sessionId: 'one', aborted: true }),
+    () => emit({ kind: 'protocol_error', sessionId: 'one' }),
+  ]) {
+    emit({ kind: 'permission_request', ...approval });
+    assert.ok(region());
+    end();
+    assert.equal(region(), null);
+  }
+});
+
+test('several requests share one section and the next remaining card is reachable', async () => {
+  const { Harness, emit } = await setup();
+  const view = render(<Harness requests={[approval, question]} />);
+  emit({ kind: 'chat_subscribed', sessionId: 'one', pendingPermissions: [approval, question] });
+  assert.equal(screen.getAllByRole('region', { name: 'Action required' }).length, 1);
+  fireEvent.click(screen.getByRole('button', { name: 'View request' }));
+  assert.equal(document.activeElement?.getAttribute('data-permission-request-id'), approval.requestId);
+  view.rerender(<Harness requests={[question]} />);
+  emit({ kind: 'permission_cancelled', ...approval });
+  fireEvent.click(screen.getByRole('button', { name: 'View request' }));
+  assert.equal(document.activeElement?.getAttribute('data-permission-request-id'), question.requestId);
+});
+
+test('a stale request never focuses another card or dismisses the drawer', async () => {
+  const { Harness, emit, shown } = await setup();
+  render(<Harness requests={[{ ...approval, requestId: 'unrelated' }]} />);
+  emit({ kind: 'permission_request', ...approval });
+  fireEvent.click(screen.getByRole('button', { name: 'View request' }));
+  assert.equal(shown(), 0);
+  assert.equal(scrolled.length, 0);
+});
+
+test('the mobile drawer closes after revealing the original question and keeps focus out of text inputs', async () => {
+  const { Harness, emit, decisions } = await setup();
+  render(<Harness mobile requests={[question]} />);
+  emit({ kind: 'permission_request', ...question });
+  assert.ok(screen.getByRole('complementary', { name: 'Agent' }));
+  fireEvent.click(screen.getByRole('button', { name: 'View request' }));
+  assert.equal(screen.queryByRole('complementary'), null);
+  assert.equal(document.activeElement?.getAttribute('data-permission-request-id'), question.requestId);
+  assert.deepEqual(decisions, []);
+});
+
+test('request ids are compared literally, including selector metacharacters', async () => {
+  const { Harness, emit } = await setup();
+  const request = { ...approval, requestId: 'request:"][data-other="value' };
+  render(<Harness requests={[request]} />);
+  emit({ kind: 'permission_request', ...request });
+  fireEvent.click(screen.getByRole('button', { name: 'View request' }));
+  assert.equal(document.activeElement?.getAttribute('data-permission-request-id'), request.requestId);
+});
+
+test('plan exits retain the existing attention policy and do not become a second approval UI', async () => {
+  const { Harness, emit } = await setup();
+  render(<Harness />);
+  for (const toolName of ['exit_plan_mode', 'ExitPlanMode']) emit({ kind: 'permission_request', sessionId: 'one', requestId: toolName, toolName });
+  assert.equal(region(), null);
+});
+
+test('Korean labels render without untranslated keys', async () => {
+  const { Harness, emit } = await setup('ko');
+  render(<Harness />);
+  emit({ kind: 'permission_request', ...approval });
+  assert.ok(screen.getByRole('region', { name: '응답 필요' }));
+  assert.ok(screen.getByRole('button', { name: '요청 보기' }));
+  assert.ok(screen.getByText('응답을 기다리고 있습니다'));
+});

--- a/src/components/agent-sidebar/view/AgentSidebarActionRequired.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarActionRequired.tsx
@@ -1,0 +1,46 @@
+import { ArrowUpRight, MessageCircleQuestion } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { useSessionAttentionStore } from '../../../stores/useSessionAttentionStore';
+import { focusPermissionRequest } from '../../chat/utils/permissionRequestFocus';
+
+type Props = {
+  sessionId?: string;
+  /** Dismiss the mobile drawer only after the request in the chat was reached. */
+  onRequestShown?: () => void;
+};
+
+/** A projection of real unanswered requests, never failed or unread outcomes. */
+export default function AgentSidebarActionRequired({ sessionId, onRequestShown }: Props) {
+  const { t } = useTranslation();
+  const pending = useSessionAttentionStore((state) => sessionId ? state.pendingInput[sessionId] : undefined);
+  if (!pending?.requestIds.length) return null;
+
+  // A running-sessions poll can know about a request before chat_subscribed
+  // restores its card. The store's server marker is not an actionable request.
+  const canShowRequest = pending.requestIds.some((id) => !id.startsWith('server:'));
+  const showRequest = () => {
+    if (focusPermissionRequest(pending.requestIds)) onRequestShown?.();
+  };
+
+  return (
+    <section aria-labelledby="agent-sidebar-action-required" className="border-t border-border/50 px-1 pt-1 pb-2 text-xs">
+      <h3 id="agent-sidebar-action-required" className="mb-1 px-2 text-[10px] font-semibold tracking-wide text-muted-foreground/80 uppercase">
+        {t('agentSidebar.actionRequired.title')}
+      </h3>
+      <p role="status" className="flex items-center gap-2 px-2 py-1.5 text-foreground">
+        <MessageCircleQuestion className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+        {t('agentSidebar.actionRequired.waiting')}
+      </p>
+      <button
+        type="button"
+        disabled={!canShowRequest}
+        onClick={showRequest}
+        className="flex min-h-11 w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-primary transition-colors hover:bg-muted/50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-default disabled:text-muted-foreground disabled:hover:bg-transparent sm:min-h-8"
+      >
+        {t(canShowRequest ? 'agentSidebar.actionRequired.viewRequest' : 'agentSidebar.actionRequired.loading')}
+        {canShowRequest && <ArrowUpRight className="h-3.5 w-3.5 shrink-0" aria-hidden />}
+      </button>
+    </section>
+  );
+}

--- a/src/components/chat/utils/permissionRequestFocus.ts
+++ b/src/components/chat/utils/permissionRequestFocus.ts
@@ -1,0 +1,14 @@
+/** Reveal an existing request without answering it or opening the mobile keyboard. */
+export function focusPermissionRequest(requestIds: readonly string[]): boolean {
+  const targets = document.querySelectorAll<HTMLElement>('[data-permission-request-id]');
+  for (const requestId of requestIds) {
+    // Compare values instead of interpolating an untrusted id into a CSS selector.
+    const target = Array.from(targets).find((element) => element.dataset.permissionRequestId === requestId);
+    if (!target) continue;
+    target.scrollIntoView({ block: 'nearest', behavior: 'instant' });
+    target.focus({ preventScroll: true });
+    return true;
+  }
+  // A request may have been answered or cancelled since the sidebar rendered.
+  return false;
+}

--- a/src/components/chat/view/PermissionRequestsBanner.tsx
+++ b/src/components/chat/view/PermissionRequestsBanner.tsx
@@ -62,11 +62,9 @@ export default function PermissionRequestsBanner({
         const CustomPanel = getPermissionPanel(request.toolName);
         if (CustomPanel) {
           return (
-            <CustomPanel
-              key={request.requestId}
-              request={request}
-              onDecision={handlePermissionDecision}
-            />
+            <div key={request.requestId} data-permission-request-id={request.requestId} tabIndex={-1} className="rounded-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+              <CustomPanel request={request} onDecision={handlePermissionDecision} />
+            </div>
           );
         }
 
@@ -79,7 +77,7 @@ export default function PermissionRequestsBanner({
         const showsAlwaysDeny = offered !== null && offered.has('reject_always');
 
         return (
-          <Confirmation key={request.requestId} approval="pending" data-tool={request.toolName}>
+          <Confirmation key={request.requestId} approval="pending" data-tool={request.toolName} data-permission-request-id={request.requestId} tabIndex={-1} className="focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
             <ConfirmationTitle className="flex items-start gap-3">
               <ShieldAlertIcon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
               <ConfirmationRequest>

--- a/src/components/main-content/view/MainContentRightRail.dom.bun.test.tsx
+++ b/src/components/main-content/view/MainContentRightRail.dom.bun.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 
 import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+import { useSessionAttentionStore } from '../../../stores/useSessionAttentionStore';
 import type { AgentSidebarProps } from '../../agent-sidebar/view/AgentSidebar';
 import type { WorkspacePanelProps } from '../../workspace/view/WorkspacePanel';
 
@@ -50,6 +51,7 @@ const originalFetch = globalThis.fetch;
 let requests: string[] = [];
 
 beforeEach(() => {
+  useSessionAttentionStore.setState({ pendingInput: {} });
   // Both rails ask the server for the same git summary; the rail is what is under test.
   requests = [];
   globalThis.fetch = (async (input) => {
@@ -60,10 +62,12 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useSessionAttentionStore.setState({ pendingInput: {} });
   globalThis.fetch = originalFetch;
 });
 
 test('with the experiment off the rail is the legacy workspace panel alone', async () => {
+  useSessionAttentionStore.getState().addPendingInput('session-alpha', 'approval-1');
   render(createElement(MainContentRightRail, props({ agentSidebarV2: false })));
 
   await screen.findByRole('tablist');
@@ -73,9 +77,11 @@ test('with the experiment off the rail is the legacy workspace panel alone', asy
   await screen.findByText('workspace.statusTab.git');
   assert.equal(screen.queryByRole('region', { name: 'agentSidebar.environment.title' }), null);
   assert.equal(screen.queryByRole('region', { name: 'agentSidebar.work.title' }), null);
+  assert.equal(screen.queryByRole('region', { name: 'agentSidebar.actionRequired.title' }), null);
 });
 
 test('with the experiment on the rail is the compact context panel alone, with the environment as its body', async () => {
+  useSessionAttentionStore.getState().addPendingInput('session-alpha', 'approval-1');
   render(createElement(MainContentRightRail, props({ agentSidebarV2: true })));
 
   const lane = await screen.findByRole('complementary', { name: 'agentSidebar.title' });
@@ -87,6 +93,7 @@ test('with the experiment on the rail is the compact context panel alone, with t
   assert.equal(lane.getAttribute('style'), null);
 
   assert.ok(screen.getByRole('region', { name: 'agentSidebar.environment.title' }));
+  assert.ok(screen.getByRole('region', { name: 'agentSidebar.actionRequired.title' }));
   await screen.findByText('main');
   // The section is fed by the same endpoint the legacy Status tab already uses; nothing new is needed.
   assert.deepEqual(requests, ['/api/git/status?project=project-alpha&sessionId=session-alpha']);

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -203,6 +203,12 @@
     "work": {
       "title": "Arbeit",
       "working": "Läuft"
+    },
+    "actionRequired": {
+      "title": "Antwort erforderlich",
+      "waiting": "Wartet auf deine Antwort",
+      "viewRequest": "Anfrage anzeigen",
+      "loading": "Anfrage wird geladen…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -203,6 +203,12 @@
     "work": {
       "title": "Work",
       "working": "Working"
+    },
+    "actionRequired": {
+      "title": "Action required",
+      "waiting": "Waiting for your response",
+      "viewRequest": "View request",
+      "loading": "Loading request…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -203,6 +203,12 @@
     "work": {
       "title": "Travail",
       "working": "En cours"
+    },
+    "actionRequired": {
+      "title": "Réponse requise",
+      "waiting": "En attente de votre réponse",
+      "viewRequest": "Voir la demande",
+      "loading": "Chargement de la demande…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -203,6 +203,12 @@
     "work": {
       "title": "Lavoro",
       "working": "In corso"
+    },
+    "actionRequired": {
+      "title": "Risposta richiesta",
+      "waiting": "In attesa della tua risposta",
+      "viewRequest": "Mostra richiesta",
+      "loading": "Caricamento della richiesta…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -201,6 +201,12 @@
     "work": {
       "title": "作業",
       "working": "実行中"
+    },
+    "actionRequired": {
+      "title": "応答が必要",
+      "waiting": "応答を待っています",
+      "viewRequest": "リクエストを表示",
+      "loading": "リクエストを読み込み中…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -201,6 +201,12 @@
     "work": {
       "title": "작업",
       "working": "작업 중"
+    },
+    "actionRequired": {
+      "title": "응답 필요",
+      "waiting": "응답을 기다리고 있습니다",
+      "viewRequest": "요청 보기",
+      "loading": "요청 불러오는 중…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -209,6 +209,12 @@
     "work": {
       "title": "Работа",
       "working": "Выполняется"
+    },
+    "actionRequired": {
+      "title": "Требуется ответ",
+      "waiting": "Ожидается ваш ответ",
+      "viewRequest": "Показать запрос",
+      "loading": "Загрузка запроса…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -203,6 +203,12 @@
     "work": {
       "title": "İş",
       "working": "Çalışıyor"
+    },
+    "actionRequired": {
+      "title": "Yanıt gerekiyor",
+      "waiting": "Yanıtınız bekleniyor",
+      "viewRequest": "İsteği görüntüle",
+      "loading": "İstek yükleniyor…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -201,6 +201,12 @@
     "work": {
       "title": "工作",
       "working": "正在执行"
+    },
+    "actionRequired": {
+      "title": "需要回复",
+      "waiting": "正在等待你的回复",
+      "viewRequest": "查看请求",
+      "loading": "正在加载请求…"
     }
   },
   "commandPalette": {

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -201,6 +201,12 @@
     "work": {
       "title": "工作",
       "working": "運行中"
+    },
+    "actionRequired": {
+      "title": "需要回覆",
+      "waiting": "正在等待你的回覆",
+      "viewRequest": "查看請求",
+      "loading": "正在載入請求…"
     }
   },
   "commandPalette": {


### PR DESCRIPTION
When the selected session is waiting for an approval or an answer, the experimental context panel now shows **Action required** below Work. **View request** reveals and focuses the original chat card without answering it. On mobile, reaching the card also dismisses the drawer without focusing a text input.

The section reads only the existing session attention store. Completed/failed outcomes and status text cannot create a request. Poll-only markers show a disabled loading action until replay restores request IDs; cancellation, answers and run termination clear the section through the existing event path. Multiple requests share one section. The experiment remains off by default, and the legacy rail, protocol and approval decisions are unchanged. All ten locales are included.

Validation:
- `npm run verify`: passed, including audit, licenses/notices, typecheck, Rust core, all test sections, lint, identity and build.
- 14 new behavioral DOM tests cover approvals, both question tool names, delegation authorization, session isolation/navigation, reload restoration, terminal cleanup, multiple/stale requests, literal request IDs, mobile focus and Korean labels.
- Existing sidebar and permission-card suites pass; right-rail tests now assert feature-flag isolation with a pending request.
- Actual browser fixture smoke at desktop and 390px mobile: compact rendering, no decision on View request, focus remains on the original card container, drawer dismissal and explicit denial cleanup. This used the production components with fixture state; no new live-model or Tauri-shell run is claimed.

Closes #71.
