### PR TITLE
feat(sidebar): surface live delegated agent activity

### DIFF
--- a/docs/GJC-DELEGATION-CONTRACT.md
+++ b/docs/GJC-DELEGATION-CONTRACT.md
@@ -34,6 +34,17 @@ assignments must carry their authoritative owner `session_id`, `run_id` and
 repository binding. Child prompts identify the app delegation ID, direct owner
 and root, and instruct writers to use the assignment's owner/run IDs explicitly.
 
+Settlement is also announced live. Once the terminal receipt is appended and
+flushed, the executor calls `onDelegationSettled` exactly once with the public
+snapshot (`delegationId`, `status`, `agent`, `description`, `executionMode`,
+`repositoryBinding`); the adapter forwards it as the writer message
+`{ kind: 'delegation_updated', delegation }`, which the worker emits as the
+scoped event `delegation.updated`. Result text and private identifiers stay on
+the server. The durable receipt remains the authority: it is written first and
+is projected into the owner transcript on reload, so the client folds live
+updates onto the same snapshot. See
+`docs/plans/delegation-lifecycle-contract.md` §10-11.
+
 The offline tests in `server/gjc-delegation-executor.bun.test.ts` exercise SDK
 0.16.4 public exports with real sessions, tools, transcripts and temporary Git
 repositories. A deterministic transport stands in for the model; it asserts

--- a/docs/GJC-WORKER-PROTOCOL.md
+++ b/docs/GJC-WORKER-PROTOCOL.md
@@ -133,6 +133,7 @@ scope is fixed by this specification, and a frame that gets it wrong is rejected
 | `tool.completed` | scoped | A tool call finished, with its result. |
 | `ask.presented` | scoped | The worker needs an answer; reply with `ask.reply`. |
 | `usage.updated` | scoped | Token or cost accounting changed. |
+| `delegation.updated` | scoped | An app-owned delegated child settled. |
 | `turn.completed` | scoped | The turn ended normally. |
 | `turn.failed` | scoped | The turn ended in failure. |
 | `oauth.phase` | global | An interactive sign-in changed phase. |
@@ -142,6 +143,23 @@ scope is fixed by this specification, and a frame that gets it wrong is rejected
 `worker.status` is the only method whose scope is optional, and it is deliberate:
 the same event reports both "this worker is alive" and "this conversation is
 still working".
+
+`delegation.updated` carries `{ runId, message }` like every other run event; the
+message is `{ kind: 'delegation_updated', delegation }` with the public
+settlement snapshot:
+
+```json
+{ "delegationId": "<uuid>", "status": "running|completed|failed|cancelled",
+  "agent": "executor", "description": "Contract task",
+  "executionMode": "default|ultragoal-red-team", "repositoryBinding": { } }
+```
+
+`executionMode` and `repositoryBinding` are optional; the private receipt fields
+(`resultText`, `file`, `owner`, `root`, `childSessionId`) are never sent. The
+worker emits exactly one such event per settlement — `completed`, `failed` or
+`cancelled` — and only after the durable receipt (`gajae-app.delegation.v1`) has
+been appended and flushed to the owner transcript. Launch is not announced here:
+the `task`/`subagent` tool result already carries the `running` snapshot.
 
 ## 5. Payload schemas
 

--- a/docs/plans/agent-sidebar-activity-model.md
+++ b/docs/plans/agent-sidebar-activity-model.md
@@ -7,6 +7,15 @@ document's section names predate that naming. Browser facts were refreshed
 after the Chromium sidecar removal (#75) and the sidebar cutover; the Aside
 browser question now has its own audit in
 [aside-activity-contract.md](aside-activity-contract.md).
+Update (2026-09-13, branch `feat/delegation-work-activity`): the delegation
+lifecycle gap this audit called the only hard gap (§"Remaining gaps" item 1,
+PR-sequence items 2-4) is resolved. `delegation.updated` is a scoped worker
+event emitted once per settlement by `GjcDelegationExecutor`, receipts are
+projected through the GJC transcript history read with the restart fold, and
+WORK lists live agents via `useSessionDelegations`. The findings below are
+kept as the historical record; see
+[delegation-lifecycle-contract.md](delegation-lifecycle-contract.md) for the
+implemented contract.
 Scope: what structured agent/runtime activity exists **today**, end to end, and
 what the smallest additional contract would be for a future `AgentSidebar`
 (Needs attention / Current work / Tasks / Agents / Review / Browser activity).

--- a/docs/plans/delegation-lifecycle-contract.md
+++ b/docs/plans/delegation-lifecycle-contract.md
@@ -1,6 +1,19 @@
 # Delegation Lifecycle Contract
 
-Status: research/documentation only — no production code changed (2026-09-13).
+Status: **implemented** (2026-09-13, branch `feat/delegation-work-activity`).
+PRs A and B of §18 landed as one PR: the executor emits one
+`delegation.updated` worker event per settlement from `#run`'s `finally` block
+(immediately after the durable terminal receipt append + flush), mapped from
+writer kind `delegation_updated`; the transcript REST read projects
+`gajae-app.delegation.v1` receipts as `delegation_updated` history rows with
+the §11.3 restart fold (`running` + no active run ⇒ `cancelled` via
+`chatRunRegistry.isProcessing`); the client folds tool-result snapshots,
+projected receipts and live events into `useSessionDelegations` (chronological
+last-wins per `delegationId`, no terminal stickiness so `resume` still works);
+and `AgentSidebarWork` renders active (`running`) agents under a compact
+Agents sublabel, suppressing the generic `Working` row while agents are
+listed. Everything below remains the design/audit record of that
+implementation.
 Base: `main` at `b86e5bd` (PR #76 merged). App pins `@gajae-code/coding-agent`
 **0.16.4** (`package.json:140`); GJC repository inspected read-only at 0.16.6.
 

--- a/server/GJC-LIVE-SPEC.md
+++ b/server/GJC-LIVE-SPEC.md
@@ -167,6 +167,14 @@ repeats the method list: the copy that used to live here had gone stale, listing
 neither `turn.steer` nor any `oauth.*` method, which is what an unchecked second
 copy does.
 
+App-owned delegation settlement rides this protocol as the scoped event
+`delegation.updated`, emitted once per settled child after its durable
+`gajae-app.delegation.v1` receipt is flushed to the owner transcript. The event
+carries only the public snapshot (`delegationId`, `status`, `agent`,
+`description`, `executionMode`, `repositoryBinding`); the transcript receipt
+projection is what restores the same rows after a reload, per
+`docs/plans/delegation-lifecycle-contract.md` §10-11.
+
 The codec rejects unknown fields, methods, unsafe identifiers, incompatible
 versions, invalid JSON values, mismatched responses, oversized or unterminated
 frames, and unknown response IDs. Pending requests fail when the worker exits.

--- a/server/gjc-bun-sdk-adapter.ts
+++ b/server/gjc-bun-sdk-adapter.ts
@@ -1075,6 +1075,9 @@ export class GjcBunSdkAdapter implements GjcWorkerRuntime {
           delegation = new GjcDelegationExecutor({
             parent: sessionManager, session: () => result.session, sessionOptions,
             permissionProvider, createSession: this.options.createSessionFactory,
+            // Settlement is reported after the durable receipt is written, so the
+            // client can fold live status onto the same authoritative snapshot.
+            onDelegationSettled: (update) => writer.send({ kind: 'delegation_updated', delegation: update }),
           });
           delegation.setToolUIContext(askController.uiContext);
         }

--- a/server/gjc-delegation-executor.bun.test.ts
+++ b/server/gjc-delegation-executor.bun.test.ts
@@ -22,7 +22,7 @@ import { convertOpenAICodexResponsesTools } from '@gajae-code/ai/providers/opena
 import type { AssistantMessage, Context, Model, SimpleStreamOptions } from '@gajae-code/ai/types';
 import * as z from 'zod/v4';
 
-import { GjcDelegationExecutor, serializeGjcDelegationAutomationTools } from './gjc-delegation-executor.js';
+import { GjcDelegationExecutor, serializeGjcDelegationAutomationTools, type GjcDelegationUpdate } from './gjc-delegation-executor.js';
 import type { GjcPermissionProvider } from './gjc-bun-permission-gate.js';
 import { GjcBunSdkAdapter } from './gjc-bun-sdk-adapter.js';
 import { installGjcCliShim } from './gjc-cli-shim.js';
@@ -70,6 +70,7 @@ async function fixture(
   provider?: GjcPermissionProvider,
   configureChild?: (options: CreateAgentSessionOptions) => CreateAgentSessionOptions | Promise<CreateAgentSessionOptions>,
   storedCredentials = false,
+  onDelegationSettled?: (update: GjcDelegationUpdate) => void,
 ) {
   const scratch = join(await realpath(process.cwd()), '.tmp');
   await mkdir(scratch, { recursive: true });
@@ -149,7 +150,7 @@ async function fixture(
   };
   const createParent = async (manager = SessionManager.create(cwd, join(root, 'sessions'))) => {
     const executor = new GjcDelegationExecutor({ parent: manager, session: () => parent, sessionOptions: base,
-      permissionProvider: provider,
+      permissionProvider: provider, onDelegationSettled,
       createSession: async (options) => {
         childInputs.push(options!);
         const result = await createAgentSession(configureChild ? await configureChild(options!) : options);
@@ -364,6 +365,71 @@ test('nested children have direct ownership, bounded depth and cascading cancell
     assert.equal(f.calls.length, 2);
   } finally { await f.close(); }
 });
+
+for (const mode of ['completed', 'failed', 'cancel', 'dispose'] as const) {
+  test(`${mode} delegation settles with exactly one public notification written after its durable receipt`, { timeout: 30_000 }, async () => {
+    const expected = mode === 'completed' ? 'completed' : mode === 'failed' ? 'failed' : 'cancelled';
+    const started = deferred();
+    const release = deferred();
+    let ended = false;
+    const state: { owner?: Session } = {};
+    const settlements: Array<{ update: GjcDelegationUpdate; receipt?: Record<string, unknown> }> = [];
+    const receiptOf = (id: string) => (state.owner!.sessionManager.getEntries() as unknown as Array<{ type: string; customType?: string; data?: Record<string, unknown> }>)
+      .filter((entry) => entry.type === 'custom' && entry.customType === 'gajae-app.delegation.v1' && entry.data?.id === id)
+      .at(-1)?.data;
+    const f = await fixture((_context, options) => {
+      const events = new AssistantMessageEventStream();
+      const cancel = () => {
+        if (ended) return;
+        ended = true;
+        const output = answer(); output.stopReason = 'aborted';
+        events.push({ type: 'error', reason: 'aborted', error: output }); events.end(output);
+      };
+      options?.signal?.addEventListener('abort', cancel, { once: true });
+      void release.promise.then(() => {
+        if (ended) return;
+        ended = true;
+        const message = answer();
+        events.push({ type: 'done', reason: 'stop', message }); events.end(message);
+      });
+      started.resolve();
+      return events;
+    }, undefined, mode === 'failed' ? () => { throw new Error('Offline child creation refused.'); } : undefined, false,
+    // The receipt is read at notification time: a live signal that arrives
+    // before the durable terminal receipt would be unverifiable by a reload.
+    (update) => settlements.push({ update, receipt: receiptOf(update.delegationId) }));
+    state.owner = f.parent;
+    try {
+      const [child] = await tool(f.parent, 'task', task());
+      assert.ok(child);
+      if (mode !== 'failed') {
+        await within(started.promise);
+        assert.deepEqual(settlements, [], 'launch is already reported by the tool result and must not notify');
+      }
+      if (mode === 'completed') release.resolve();
+      const settle = async () => {
+        if (mode === 'cancel') await within(tool(f.parent, 'subagent', { action: 'cancel', id: child.id }), 10_000);
+        else if (mode === 'dispose') await within(f.executor.dispose(), 10_000);
+        else await within(tool(f.parent, 'subagent', { action: 'await', id: child.id }), 10_000);
+      };
+      await settle();
+      assert.equal(settlements.length, 1, JSON.stringify({ settlements, errors: f.transportErrors.map(String) }));
+      const [settled] = settlements;
+      assert.ok(settled?.receipt, 'the terminal receipt must already be durable when the notification fires');
+      assert.equal(settled.receipt.status, expected);
+      assert.deepEqual(settled.update, {
+        delegationId: child.id, status: expected, agent: 'executor', description: 'Contract task',
+        executionMode: 'default', repositoryBinding: settled.receipt.repositoryBinding,
+      });
+      for (const secret of ['resultText', 'file', 'owner', 'root', 'childSessionId']) {
+        assert.equal(secret in settled.update, false, `${secret} must never leave the server`);
+      }
+      // A repeated terminal operation observes the settled job, never a second settlement.
+      await settle();
+      assert.equal(settlements.length, 1);
+    } finally { release.resolve(); await f.close(); }
+  });
+}
 
 for (const operation of ['cancel', 'dispose'] as const) {
   test(`${operation} reports a rejected child abort safely and retries it through the public executor`, { timeout: 30_000 }, async () => {

--- a/server/gjc-delegation-executor.ts
+++ b/server/gjc-delegation-executor.ts
@@ -80,6 +80,21 @@ type Job = {
 export const GJC_APP_DELEGATION_TOOL_NAMES = ['task', 'subagent'] as const;
 export const GJC_DELEGATION_LIMITS = Object.freeze({ concurrency: 4, depth: 2, launches: 32, runtimeMs: 300_000 });
 
+/**
+ * The public settlement snapshot: exactly the fields `#snapshot` exposes minus
+ * the result text. Private identifiers and transcript content never travel on
+ * the live signal; the durable receipt in the owner transcript stays the
+ * authority for anything richer.
+ */
+export type GjcDelegationUpdate = {
+  delegationId: string;
+  status: Receipt['status'];
+  agent: Receipt['agent'];
+  description: Receipt['description'];
+  executionMode?: Receipt['executionMode'];
+  repositoryBinding?: Receipt['repositoryBinding'];
+};
+
 export type GjcDelegationOptions = {
   parent: SessionManager;
   session: () => Session;
@@ -87,7 +102,15 @@ export type GjcDelegationOptions = {
   sessionOptions: CreateAgentSessionOptions;
   permissionProvider?: GjcPermissionProvider;
   createSession?: typeof createAgentSession;
+  /** Fired once per settlement, after the terminal receipt is durable. */
+  onDelegationSettled?: (update: GjcDelegationUpdate) => void;
 };
+
+function delegationUpdate(receipt: Receipt): GjcDelegationUpdate {
+  const { id, file: _file, owner: _owner, root: _root, childSessionId: _session,
+    resultText: _resultText, ...publicReceipt } = receipt;
+  return { delegationId: id, ...publicReceipt };
+}
 
 function result(value: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(value) }], details: value };
@@ -478,6 +501,10 @@ export class GjcDelegationExecutor {
       if (job.controller.signal.aborted || this.#closed.signal.aborted) job.receipt.status = 'cancelled';
       job.owner.manager.appendCustomEntry(RECEIPT, { ...job.receipt });
       await job.owner.manager.flush();
+      // The durable receipt is the authority, so it is always written first.
+      // A throwing consumer is a live-signal problem, never a settlement one.
+      try { this.options.onDelegationSettled?.(delegationUpdate(job.receipt)); }
+      catch { /* The receipt above already records this settlement. */ }
     }
   }
 

--- a/server/gjc-worker-protocol.test.ts
+++ b/server/gjc-worker-protocol.test.ts
@@ -45,7 +45,7 @@ test('declares the independent worker protocol v1 surface', () => {
   assert.equal(GJC_WORKER_PROTOCOL_VERSION, 1);
   assert.equal(GJC_WORKER_MAX_FRAME_BYTES, 64 * 1024 * 1024);
   assert.deepEqual(GJC_WORKER_REQUEST_METHODS, ['worker.initialize', 'worker.activity', 'worker.admission', 'session.start', 'session.resume', 'turn.start', 'turn.abort', 'turn.steer', 'goal.inspect', 'goal.control', 'ask.reply', 'models.catalog', 'oauth.providers', 'oauth.status', 'oauth.start', 'oauth.submit', 'oauth.cancel', 'worker.shutdown']);
-  assert.deepEqual(GJC_WORKER_EVENT_METHODS, ['session.created', 'message.delta', 'message.completed', 'tool.started', 'tool.completed', 'ask.presented', 'usage.updated', 'turn.completed', 'turn.failed', 'worker.status', 'oauth.phase', 'oauth.providers.updated', 'provider.auth.updated']);
+  assert.deepEqual(GJC_WORKER_EVENT_METHODS, ['session.created', 'message.delta', 'message.completed', 'tool.started', 'tool.completed', 'ask.presented', 'usage.updated', 'delegation.updated', 'turn.completed', 'turn.failed', 'worker.status', 'oauth.phase', 'oauth.providers.updated', 'provider.auth.updated']);
 });
 
 test('parses every request method and enforces scope, fields, and protocolVersion', () => {
@@ -64,6 +64,10 @@ test('parses every event method with required IDs and correct session scope', ()
   }
   assert.equal(parseGjcWorkerFrame(JSON.stringify({ protocolVersion: 1, kind: 'event', id: 'event-1', method: 'worker.status', sessionId: 'session-1', payload: {} })).method, 'worker.status');
   protocolError(() => parseGjcWorkerFrame(JSON.stringify({ protocolVersion: 1, kind: 'event', id: 'event-2', method: 'turn.completed', payload: {} })), 'invalid_session_id');
+  // Delegation settlement belongs to exactly one session; a session-less frame
+  // would leak child activity into every other scope.
+  assert.equal(parseGjcWorkerFrame(JSON.stringify({ protocolVersion: 1, kind: 'event', id: 'event-3', method: 'delegation.updated', sessionId: 'session-1', payload: { runId: 'run-1', message: { kind: 'delegation_updated', delegation: { delegationId: 'delegation-1', status: 'completed', agent: 'executor', description: 'Contract task' } } } })).method, 'delegation.updated');
+  protocolError(() => parseGjcWorkerFrame(JSON.stringify({ protocolVersion: 1, kind: 'event', id: 'event-4', method: 'delegation.updated', payload: {} })), 'invalid_session_id');
   protocolError(() => parseGjcWorkerFrame(JSON.stringify({ protocolVersion: 1, kind: 'event', method: 'worker.status', payload: {} })), 'invalid_id');
 });
 

--- a/server/gjc-worker-protocol.ts
+++ b/server/gjc-worker-protocol.ts
@@ -34,6 +34,7 @@ export const GJC_WORKER_EVENT_METHODS = [
   'tool.completed',
   'ask.presented',
   'usage.updated',
+  'delegation.updated',
   'turn.completed',
   'turn.failed',
   'worker.status',

--- a/server/gjc-worker.test.ts
+++ b/server/gjc-worker.test.ts
@@ -210,9 +210,12 @@ test('maps events with immutable run identity and captures provider sessions', a
   const { fake, host, frames } = await initialized();
   const pending = host.handle(request('session.start', 'run-1', { message: 'hello', options: {} })); await Promise.resolve();
   const writer = fake.runs[0].writer!;
-  writer.setSessionId!('provider-1'); writer.send({ kind: 'stream_delta', content: 'hi' }); writer.send({ kind: 'tool_use' }); writer.send({ kind: 'tool_result' }); writer.send({ kind: 'permission_request' }); writer.send({ kind: 'status', text: 'token_budget' }); writer.send({ kind: 'complete', exitCode: 0 });
-  const events = frames.slice(1) as Array<{ method: string; payload: { runId: string } }>;
-  assert.deepEqual(events.map((frame) => frame.method), ['worker.status', 'session.created', 'message.delta', 'tool.started', 'tool.completed', 'ask.presented', 'usage.updated', 'turn.completed']);
+  writer.setSessionId!('provider-1'); writer.send({ kind: 'stream_delta', content: 'hi' }); writer.send({ kind: 'tool_use' }); writer.send({ kind: 'tool_result' }); writer.send({ kind: 'permission_request' }); writer.send({ kind: 'status', text: 'token_budget' }); writer.send({ kind: 'delegation_updated', delegation: { delegationId: 'delegation-1', status: 'completed', agent: 'executor', description: 'Contract task' } }); writer.send({ kind: 'complete', exitCode: 0 });
+  const events = frames.slice(1) as Array<{ method: string; payload: { runId: string; message?: { delegation?: { delegationId: string } } } }>;
+  assert.deepEqual(events.map((frame) => frame.method), ['worker.status', 'session.created', 'message.delta', 'tool.started', 'tool.completed', 'ask.presented', 'usage.updated', 'delegation.updated', 'turn.completed']);
+  // The settlement signal rides the ordinary scoped message channel, so an
+  // unmapped kind cannot silently degrade into message.completed.
+  assert.equal(events.find((frame) => frame.method === 'delegation.updated')?.payload.message?.delegation?.delegationId, 'delegation-1');
   assert.ok(events.every((frame) => frame.payload.runId === 'run-1'));
   fake.runs[0].run.resolve();
   await pending;

--- a/server/gjc-worker.ts
+++ b/server/gjc-worker.ts
@@ -557,6 +557,9 @@ export class GjcWorkerHost {
     // usage channel: they update at the same moment and the client handler
     // already subscribes to it.
     else if (message.kind === 'status' && message.text === 'session_state') method = 'usage.updated';
+    // Unmapped kinds fall through to message.completed, so the authoritative
+    // delegation settlement signal needs its own explicit mapping.
+    else if (message.kind === 'delegation_updated') method = 'delegation.updated';
     else if (message.kind === 'complete') method = message.exitCode === 0 ? 'turn.completed' : 'turn.failed';
     this.#event(run, method, { message });
   }

--- a/server/modules/providers/list/gjc/gjc-sessions.provider.ts
+++ b/server/modules/providers/list/gjc/gjc-sessions.provider.ts
@@ -4,7 +4,7 @@ import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderSessions } from '@/shared/interfaces.js';
 import type { AnyRecord, FetchHistoryOptions, FetchHistoryResult, NormalizedMessage } from '@/shared/types.js';
 import { assignTranscriptTurns, type TranscriptTurnRecord } from '@/modules/providers/list/gjc/gjc-transcript-turns.js';
-import { readGjcTranscriptMessage } from '@/modules/providers/list/gjc/gjc-transcript-message.js';
+import { type GjcDelegationReceiptUpdate, readGjcDelegationReceipt, readGjcTranscriptMessage } from '@/modules/providers/list/gjc/gjc-transcript-message.js';
 import { AppError, createNormalizedMessage, generateMessageId, readObjectRecord } from '@/shared/utils.js';
 
 const PROVIDER = 'gjc';
@@ -144,6 +144,23 @@ async function streamGjcSessionMessages(
       try {
         const entry = readObjectRecord(JSON.parse(line));
         if (!entry) {
+          continue;
+        }
+
+        // A delegation receipt is a custom entry, not a message, so the
+        // message reader above returns null for it and the skip below would
+        // drop the only durable record of the delegation's state.
+        const delegation = readGjcDelegationReceipt(entry);
+        if (delegation) {
+          const receiptId = typeof entry.id === 'string' ? entry.id : generateMessageId(PROVIDER);
+          const receiptTurn = typeof entry.id === 'string' ? turns.get(entry.id) : undefined;
+          const record: AnyRecord = {
+            uuid: `${receiptId}:delegation`,
+            type: 'delegation_receipt',
+            timestamp: entry.timestamp,
+            delegation,
+          };
+          onMessage(receiptTurn ? { ...record, turnId: receiptTurn.turnId, turnStatus: receiptTurn.status } : record);
           continue;
         }
 
@@ -332,15 +349,15 @@ export class GjcSessionsProvider implements IProviderSessions {
    * one omission there would leave a message out of its turn, and a
    * changed-files card silently short of what the turn actually changed.
    */
-  private normalizeHistoryEntry(raw: AnyRecord, sessionId: string | null): NormalizedMessage[] {
-    const messages = this.normalizeHistoryEntryContent(raw, sessionId);
+  private normalizeHistoryEntry(raw: AnyRecord, sessionId: string | null, sessionIsRunning = false): NormalizedMessage[] {
+    const messages = this.normalizeHistoryEntryContent(raw, sessionId, sessionIsRunning);
     const turnId = typeof raw.turnId === 'string' ? raw.turnId : undefined;
     if (!turnId) return messages;
     const turnStatus = raw.turnStatus as NormalizedMessage['turnStatus'];
     return messages.map((message) => ({ ...message, turnId, turnStatus }));
   }
 
-  private normalizeHistoryEntryContent(raw: AnyRecord, sessionId: string | null): NormalizedMessage[] {
+  private normalizeHistoryEntryContent(raw: AnyRecord, sessionId: string | null, sessionIsRunning: boolean): NormalizedMessage[] {
     const ts = raw.timestamp || new Date().toISOString();
     const baseId = raw.uuid || generateMessageId(PROVIDER);
 
@@ -358,6 +375,27 @@ export class GjcSessionsProvider implements IProviderSessions {
         provider: PROVIDER,
         kind: 'thinking',
         content: thinkingContent,
+      })];
+    }
+
+    if (raw.type === 'delegation_receipt') {
+      const delegation = raw.delegation as GjcDelegationReceiptUpdate | undefined;
+      if (!delegation) {
+        return [];
+      }
+      // The executor's own restart rule (`#receipts`), applied at read time: a
+      // `running` receipt is true only while the session still has a live run.
+      // No child survives a worker or server restart, so a receipt left running
+      // by a lost process reads `cancelled` instead of running forever.
+      return [createNormalizedMessage({
+        id: baseId,
+        sessionId,
+        timestamp: ts,
+        provider: PROVIDER,
+        kind: 'delegation_updated',
+        delegation: delegation.status === 'running' && !sessionIsRunning
+          ? { ...delegation, status: 'cancelled' }
+          : delegation,
       })];
     }
 
@@ -475,6 +513,11 @@ export class GjcSessionsProvider implements IProviderSessions {
     normalizedOffset: number,
   ): Promise<FetchHistoryResult> {
     const revision = await fsSync.promises.stat(sessionFilePath);
+    // Read once per page so both passes project the same delegation state, and
+    // imported lazily because the run registry's module graph reaches back into
+    // the provider registry - a static edge here is an import cycle.
+    const { chatRunRegistry } = await import('@/modules/websocket/index.js');
+    const sessionIsRunning = chatRunRegistry.isProcessing(sessionId);
     const cached = this.readHistoryIndexCache(sessionFilePath, revision.size, revision.mtimeMs);
     let turns: HistoryIndexCacheEntry['turns'];
     let chronological: HistoryRow[];
@@ -490,7 +533,7 @@ export class GjcSessionsProvider implements IProviderSessions {
       // pagination offsets or evict older messages from a payload ring.
       const index: HistoryRow[] = [];
       await streamGjcSessionMessages(sessionFilePath, turns, raw => {
-        for (const message of this.normalizeHistoryEntry(raw, sessionId)) {
+        for (const message of this.normalizeHistoryEntry(raw, sessionId, sessionIsRunning)) {
           const time = Date.parse(message.timestamp);
           index.push({ ordinal: index.length, time: Number.isFinite(time) ? time : 0, kind: message.kind, toolId: message.toolId });
         }
@@ -519,7 +562,7 @@ export class GjcSessionsProvider implements IProviderSessions {
     let ordinal = 0;
     let bytes = 0;
     if (wanted.size) await streamGjcSessionMessages(sessionFilePath, turns, raw => {
-      for (const message of this.normalizeHistoryEntry(raw, sessionId)) {
+      for (const message of this.normalizeHistoryEntry(raw, sessionId, sessionIsRunning)) {
         const position = ordinal++;
         if (!wanted.has(position)) continue;
         bytes += Buffer.byteLength(JSON.stringify(message), 'utf8');

--- a/server/modules/providers/list/gjc/gjc-transcript-message.ts
+++ b/server/modules/providers/list/gjc/gjc-transcript-message.ts
@@ -32,3 +32,60 @@ export function readGjcTranscriptMessage(value: unknown): AnyRecord | null {
     content: `/skill:${details.name}${details.args ? ` ${details.args}` : ''}`,
   };
 }
+
+/**
+ * The public delegation snapshot carried by a projected receipt row: identity
+ * and state only. The durable receipt keeps `resultText`, `file`, `owner`,
+ * `root` and `childSessionId`, and none of them may reach the browser.
+ */
+export type GjcDelegationReceiptUpdate = {
+  delegationId: string;
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  agent: string;
+  description: string;
+  executionMode?: 'default' | 'ultragoal-red-team';
+  repositoryBinding?: AnyRecord;
+};
+
+const DELEGATION_RECEIPT_TYPE = 'gajae-app.delegation.v1';
+const DELEGATION_STATUSES = new Set<GjcDelegationReceiptUpdate['status']>(['running', 'completed', 'failed', 'cancelled']);
+const DELEGATION_EXECUTION_MODES = new Set<NonNullable<GjcDelegationReceiptUpdate['executionMode']>>(['default', 'ultragoal-red-team']);
+
+/**
+ * Reads an App delegation receipt (`gajae-app.delegation.v1`) written into the
+ * owner's transcript by `GjcDelegationExecutor`.
+ *
+ * Deliberately narrow on both ends: only this one custom type is read - every
+ * other custom entry an extension or the runtime may append stays invisible -
+ * and only the public snapshot fields leave the function, so a widened receipt
+ * can never leak child identifiers or result text into history.
+ */
+export function readGjcDelegationReceipt(value: unknown): GjcDelegationReceiptUpdate | null {
+  const entry = readObjectRecord(value);
+  if (!entry || entry.type !== 'custom' || entry.customType !== DELEGATION_RECEIPT_TYPE) return null;
+
+  const data = readObjectRecord(entry.data);
+  if (!data) return null;
+
+  const { id, status, agent, description, executionMode } = data;
+  if (
+    typeof id !== 'string' || !id
+    || typeof status !== 'string' || !DELEGATION_STATUSES.has(status as GjcDelegationReceiptUpdate['status'])
+    || typeof agent !== 'string' || !agent
+    || typeof description !== 'string'
+  ) return null;
+  if (
+    executionMode !== undefined
+    && (typeof executionMode !== 'string' || !DELEGATION_EXECUTION_MODES.has(executionMode as NonNullable<GjcDelegationReceiptUpdate['executionMode']>))
+  ) return null;
+
+  const repositoryBinding = readObjectRecord(data.repositoryBinding);
+  return {
+    delegationId: id,
+    status: status as GjcDelegationReceiptUpdate['status'],
+    agent,
+    description,
+    ...(executionMode === undefined ? {} : { executionMode: executionMode as NonNullable<GjcDelegationReceiptUpdate['executionMode']> }),
+    ...(repositoryBinding ? { repositoryBinding } : {}),
+  };
+}

--- a/server/modules/providers/services/session-export.service.ts
+++ b/server/modules/providers/services/session-export.service.ts
@@ -138,6 +138,12 @@ function renderMessage(message: NormalizedMessage): string | null {
     case 'task_notification':
       return `> ${stringify(message.content)}`;
 
+    // Delegation lifecycle rows carry no prose at all; what the delegated work
+    // actually produced is already in the transcript as the tool result the
+    // model read. Rendering the state machine would only add empty headings.
+    case 'delegation_updated':
+      return null;
+
     default: {
       const content = stringify(message.content);
       const attachments = Array.isArray(message.images) ? message.images.length : 0;

--- a/server/modules/providers/tests/gjc-sessions.test.ts
+++ b/server/modules/providers/tests/gjc-sessions.test.ts
@@ -10,6 +10,7 @@ import { GjcSessionSynchronizer } from '@/modules/providers/list/gjc/gjc-session
 import { GjcSessionsProvider } from '@/modules/providers/list/gjc/gjc-sessions.provider.js';
 import { exportSessionTranscript } from '@/modules/providers/services/session-export.service.js';
 import { fetchCompleteHistory, sessionsService } from '@/modules/providers/services/sessions.service.js';
+import { chatRunRegistry } from '@/modules/websocket/index.js';
 
 const patchHomeDir = (nextHomeDir: string) => {
   const original = os.homedir;
@@ -1146,6 +1147,165 @@ test('gjc history index cache keeps mid-read HISTORY_CHANGED retry behavior', { 
       } finally {
         (fs.promises as { stat: unknown }).stat = originalStat;
       }
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Writes a transcript holding App delegation receipts.
+ *
+ * Receipts are `custom` entries appended into the *owner's* transcript by
+ * `GjcDelegationExecutor`, carrying the whole receipt - private child
+ * identifiers and result text included - which is exactly why the projection
+ * must be narrow.
+ */
+const writeDelegationTranscript = async (
+  tempRoot: string,
+  sessionId: string,
+  workspacePath: string,
+  entries: Array<Record<string, unknown>>,
+): Promise<string> => {
+  const sessionsDir = path.join(tempRoot, '.gjc', 'agent', 'sessions', '-workspace');
+  await mkdir(sessionsDir, { recursive: true });
+  const lines = [
+    JSON.stringify({ type: 'session', version: 3, id: sessionId, timestamp: '2026-07-09T00:00:00.000Z', cwd: workspacePath }),
+    JSON.stringify({ type: 'message', id: 'msg-1', parentId: null, timestamp: '2026-07-09T00:00:01.000Z', message: { role: 'user', content: [{ type: 'text', text: 'Delegate this' }] } }),
+    ...entries.map((entry) => JSON.stringify(entry)),
+  ];
+  const filePath = path.join(sessionsDir, `2026-07-09T00-00-00_${sessionId}.jsonl`);
+  await writeFile(filePath, `${lines.join('\n')}\n`, 'utf8');
+  return filePath;
+};
+
+const delegationReceipt = (id: string, index: number, status: string, overrides: Record<string, unknown> = {}) => ({
+  type: 'custom',
+  customType: 'gajae-app.delegation.v1',
+  id: `receipt-${id}-${index}`,
+  parentId: index === 1 ? 'msg-1' : `receipt-${id}-${index - 1}`,
+  timestamp: `2026-07-09T00:00:0${index + 1}.000Z`,
+  data: {
+    id,
+    owner: 'owner-session-id',
+    root: 'root-session-id',
+    childSessionId: 'child-session-id',
+    file: 'child-transcript.jsonl',
+    agent: 'executor',
+    executionMode: 'default',
+    repositoryBinding: { repositoryRoot: '/tmp/repo' },
+    description: 'Ship the projection',
+    status,
+    resultText: 'child result nobody outside the model may read',
+    ...overrides,
+  },
+});
+
+const fakeConnection = { send() {}, readyState: 1 };
+
+test('gjc history projects delegation receipts and the terminal one wins by order', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gjc-delegation-history-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    const sessionId = 'gjc-delegation-pair';
+    const filePath = await writeDelegationTranscript(tempRoot, sessionId, workspacePath, [
+      delegationReceipt('delegation-1', 1, 'running'),
+      delegationReceipt('delegation-1', 2, 'completed'),
+    ]);
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(sessionId, 'gjc', workspacePath, undefined, undefined, undefined, filePath);
+      const history = await new GjcSessionsProvider().fetchHistory(sessionId);
+
+      assert.equal(history.total, 3, 'the user message plus both receipts are visible rows');
+      const receipts = history.messages.filter((message) => message.kind === 'delegation_updated');
+      assert.equal(receipts.length, 2);
+      // Append-only receipts: the later entry is the delegation's real state.
+      assert.equal((receipts.at(-1)?.delegation as { status: string }).status, 'completed');
+
+      // Exactly the public snapshot - no child identity, no result text.
+      assert.deepEqual(receipts.at(-1)?.delegation, {
+        delegationId: 'delegation-1',
+        status: 'completed',
+        agent: 'executor',
+        description: 'Ship the projection',
+        executionMode: 'default',
+        repositoryBinding: { repositoryRoot: '/tmp/repo' },
+      });
+      const serialized = JSON.stringify(history.messages);
+      for (const secret of ['child result nobody', 'child-session-id', 'owner-session-id', 'root-session-id', 'child-transcript.jsonl']) {
+        assert.equal(serialized.includes(secret), false, `${secret} must never reach history`);
+      }
+
+      // A saved conversation is prose; the lifecycle row contributes nothing.
+      const exported = await exportSessionTranscript(sessionId);
+      assert.equal(exported.body.includes('delegation-1'), false);
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('gjc history reads a stale running receipt as cancelled and a live one as running', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gjc-delegation-restart-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    const sessionId = 'gjc-delegation-running';
+    const filePath = await writeDelegationTranscript(tempRoot, sessionId, workspacePath, [
+      delegationReceipt('delegation-live', 1, 'running'),
+    ]);
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(sessionId, 'gjc', workspacePath, undefined, undefined, undefined, filePath);
+      const provider = new GjcSessionsProvider();
+
+      // No run owns the session: the child process cannot have survived, so the
+      // executor's restart rule settles the receipt.
+      chatRunRegistry.clearAll();
+      const restarted = await provider.fetchHistory(sessionId);
+      assert.equal((restarted.messages.at(-1)?.delegation as { status: string }).status, 'cancelled');
+
+      try {
+        const run = chatRunRegistry.startRun({
+          appSessionId: sessionId,
+          provider: 'gjc',
+          providerSessionId: sessionId,
+          connection: fakeConnection,
+          userId: 'user-1',
+        });
+        assert.ok(run);
+        const live = await provider.fetchHistory(sessionId);
+        assert.equal((live.messages.at(-1)?.delegation as { status: string }).status, 'running');
+      } finally {
+        chatRunRegistry.clearAll();
+      }
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('gjc history keeps every other custom transcript entry invisible', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gjc-delegation-custom-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    const sessionId = 'gjc-delegation-custom';
+    const filePath = await writeDelegationTranscript(tempRoot, sessionId, workspacePath, [
+      { type: 'custom', customType: 'goal-completed', id: 'custom-1', parentId: 'msg-1', timestamp: '2026-07-09T00:00:02.000Z', data: { id: 'x', status: 'completed', agent: 'executor', description: 'not a delegation' } },
+      { type: 'custom', customType: 'gajae-app.delegation.v2', id: 'custom-2', parentId: 'custom-1', timestamp: '2026-07-09T00:00:03.000Z', data: { id: 'y', status: 'running', agent: 'executor', description: 'future format' } },
+      // Right type, malformed payload: an unknown status is not a state.
+      { type: 'custom', customType: 'gajae-app.delegation.v1', id: 'custom-3', parentId: 'custom-2', timestamp: '2026-07-09T00:00:04.000Z', data: { id: 'z', status: 'queued', agent: 'executor', description: 'invented state' } },
+    ]);
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(sessionId, 'gjc', workspacePath, undefined, undefined, undefined, filePath);
+      const history = await new GjcSessionsProvider().fetchHistory(sessionId);
+
+      assert.equal(history.total, 1);
+      assert.equal(history.messages[0]?.content, 'Delegate this');
     });
   } finally {
     await rm(tempRoot, { recursive: true, force: true });

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -22,7 +22,7 @@ export interface ProviderCurrentActiveModel { model: string; }
 export interface ProviderChangeActiveModelInput { model: string; sessionId: string; }
 export interface ProviderSessionActiveModelChange { changed: boolean; model: string | null; provider: LLMProvider; sessionId: string; supported: boolean; }
 
-type MessageKind = 'text' | 'tool_use' | 'tool_result' | 'thinking' | 'stream_delta' | 'stream_end' | 'error' | 'complete' | 'status' | 'permission_request' | 'permission_cancelled' | 'session_created' | 'session_title' | 'interactive_prompt' | 'task_notification' | 'system_notice';
+type MessageKind = 'text' | 'tool_use' | 'tool_result' | 'thinking' | 'stream_delta' | 'stream_end' | 'error' | 'complete' | 'status' | 'permission_request' | 'permission_cancelled' | 'session_created' | 'session_title' | 'interactive_prompt' | 'task_notification' | 'system_notice' | 'delegation_updated';
 interface NormalizedToolResult { content?: string; isError?: boolean; toolUseResult?: unknown; }
 export interface NormalizedMessage {
   id: string; sessionId: string; timestamp: string; provider: LLMProvider; kind: MessageKind;
@@ -30,6 +30,8 @@ export interface NormalizedMessage {
   content?: string; displayText?: string; commandName?: string; commandMessage?: string; commandArgs?: string; isLocalCommand?: boolean; isLocalCommandStdout?: boolean; isCompactSummary?: boolean;
   images?: unknown; toolName?: string; toolInput?: unknown; toolId?: string; toolResult?: NormalizedToolResult; toolResultTruncated?: boolean; toolResultBytes?: number; toolDetailsOmitted?: boolean;
   isError?: boolean; level?: 'info' | 'warning' | 'error'; text?: string; tokens?: number; canInterrupt?: boolean; requestId?: string; input?: unknown; context?: unknown; reason?: string; newSessionId?: string; status?: string; summary?: string; tokenBudget?: unknown; subagentTools?: unknown; toolUseResult?: unknown; sequence?: number; rowid?: number;
+  /** `delegation_updated` payload: the public delegation snapshot `{delegationId, status, agent, description, executionMode?, repositoryBinding?}`. Never `resultText`, `file`, `owner`, `root` or `childSessionId` - the owner transcript's receipt stays the authority for those. */
+  delegation?: unknown;
   [key: string]: unknown;
 }
 

--- a/src/components/agent-sidebar/view/AgentSidebarWork.dom.bun.test.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarWork.dom.bun.test.tsx
@@ -54,8 +54,48 @@ function createStore() {
       } as unknown as NormalizedMessage]);
       listeners.get(id)?.forEach((listener) => listener());
     },
+    /** Appends the delegation tool's structured result, the way a started delegation lands. */
+    delegate: (id: string, subagents: Array<Record<string, unknown>>) => {
+      sequence += 1;
+      messages.set(id, [...(messages.get(id) ?? []), {
+        id: `task-${sequence}`, sessionId: id, provider: 'gjc', kind: 'tool_use',
+        timestamp: '2026-09-12T00:01:00Z', toolId: `task-${sequence}`, toolName: 'task',
+        toolInput: {}, toolResult: { content: 'Started', isError: false, toolUseResult: { subagents } },
+      } as unknown as NormalizedMessage]);
+      listeners.get(id)?.forEach((listener) => listener());
+    },
+    /** Appends a started delegation the way the live stream delivers it: call row, then a standalone result row. */
+    delegateLive: (id: string, subagents: Array<Record<string, unknown>>) => {
+      sequence += 1;
+      messages.set(id, [...(messages.get(id) ?? []),
+        {
+          id: `task-${sequence}`, sessionId: id, provider: 'gjc', kind: 'tool_use',
+          timestamp: '2026-09-12T00:01:00Z', toolId: `task-${sequence}`, toolName: 'task',
+          toolInput: {},
+        } as unknown as NormalizedMessage,
+        {
+          id: `result-${sequence}`, sessionId: id, provider: 'gjc', kind: 'tool_result',
+          timestamp: '2026-09-12T00:01:01Z', toolId: `task-${sequence}`,
+          content: 'Started', isError: false, isFinal: true, toolUseResult: { subagents },
+        } as unknown as NormalizedMessage,
+      ]);
+      listeners.get(id)?.forEach((listener) => listener());
+    },
+    /** Appends the authoritative settlement row the executor emits per receipt. */
+    settle: (id: string, delegation: Record<string, unknown>) => {
+      sequence += 1;
+      messages.set(id, [...(messages.get(id) ?? []), {
+        id: `settle-${sequence}`, sessionId: id, provider: 'gjc', kind: 'delegation_updated',
+        timestamp: '2026-09-12T00:02:00Z', delegation,
+      } as unknown as NormalizedMessage]);
+      listeners.get(id)?.forEach((listener) => listener());
+    },
   };
 }
+
+const agent = (overrides: Record<string, unknown> = {}) => ({
+  id: 'd1', status: 'running', agent: 'executor', description: 'Wire the WORK lane', ...overrides,
+});
 
 function running(sessionId: string): SessionStatusSnapshot {
   return { ...EMPTY_SESSION_STATUS, sessionId, activity: { running: true, statusText: null, queued: 0 } };
@@ -248,6 +288,123 @@ test('the list follows the session window live and unsubscribes when the session
   view.rerender(state.ui(undefined));
   assert.equal(view.container.innerHTML, '');
   assert.equal(state.listeners('session-1'), 0);
+});
+
+test('an idle session with neither todos nor agents still renders nothing', async () => {
+  const state = await setup();
+  state.settle('session-1', { delegationId: 'd1', status: 'completed', agent: 'executor', description: 'Wire the WORK lane' });
+  const view = render(state.ui('session-1'));
+  assert.equal(view.container.innerHTML, '');
+});
+
+test('a live stream result row settles onto its call and lists the agent without a reload', async () => {
+  const state = await setup();
+  state.delegateLive('session-1', [agent()]);
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  assert.ok(within(region).getByText('Executor — Wire the WORK lane'));
+  assert.equal(within(region).queryByText('Working'), null);
+
+  // The run itself is still active, so the lane falls back to its generic row.
+  act(() => state.settle('session-1', { delegationId: 'd1', status: 'completed', agent: 'executor', description: 'Wire the WORK lane' }));
+  assert.equal(within(section()).queryByText('Executor — Wire the WORK lane'), null);
+  assert.ok(within(section()).getByText('Working'));
+});
+
+test('a running agent replaces the generic Working row: the agent is the better answer', async () => {
+  const state = await setup();
+  state.delegate('session-1', [agent()]);
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  assert.ok(within(region).getByText('Agents'));
+  assert.ok(within(region).getByText('Executor — Wire the WORK lane'));
+  assert.equal(within(region).queryByText('Working'), null);
+  const row = within(region).getByText('Executor — Wire the WORK lane').closest('li')!;
+  assert.match(row.textContent!, /Running:/);
+  assert.match(row.querySelector('svg')!.getAttribute('class')!, /animate-spin/);
+});
+
+test('a session with todos and a running agent shows both, tasks first', async () => {
+  const state = await setup();
+  state.publish('session-1', plan);
+  state.delegate('session-1', [agent()]);
+  render(state.ui('session-1', running('session-1')));
+
+  const region = section();
+  const rows = within(region).getAllByRole('listitem');
+  assert.equal(rows.length, 5);
+  assert.match(rows[0].textContent!, /Inspect current code/);
+  assert.match(rows[4].textContent!, /Executor — Wire the WORK lane/);
+  assert.equal(within(region).queryByText('Working'), null);
+});
+
+test('every active agent is listed; the concurrency limit keeps the block compact', async () => {
+  const state = await setup();
+  state.delegate('session-1', [
+    agent({ id: 'd1', agent: 'planner', description: 'Sequence the work' }),
+    agent({ id: 'd2', agent: 'executor', description: 'Server lane' }),
+    agent({ id: 'd3', agent: 'critic', description: 'Review the plan' }),
+  ]);
+  render(state.ui('session-1'));
+
+  const rows = within(section()).getAllByRole('listitem');
+  assert.deepEqual(rows.map((row) => row.querySelector('span:last-child')!.textContent), [
+    'Planner — Sequence the work', 'Executor — Server lane', 'Critic — Review the plan',
+  ]);
+});
+
+test('a settled agent leaves the lane as soon as its receipt lands', async () => {
+  const state = await setup();
+  state.delegate('session-1', [agent({ id: 'd1' }), agent({ id: 'd2', agent: 'planner', description: 'Sequence the work' })]);
+  render(state.ui('session-1'));
+  assert.equal(within(section()).getAllByRole('listitem').length, 2);
+
+  act(() => state.settle('session-1', { delegationId: 'd1', status: 'completed', agent: 'executor', description: 'Wire the WORK lane' }));
+  const rows = within(section()).getAllByRole('listitem');
+  assert.equal(rows.length, 1);
+  assert.match(rows[0].textContent!, /Planner — Sequence the work/);
+
+  // The last agent settling empties the lane entirely: WORK is now-only.
+  act(() => state.settle('session-1', { delegationId: 'd2', status: 'cancelled', agent: 'planner', description: 'Sequence the work' }));
+  assert.equal(screen.queryByRole('region', { name: 'Work' }), null);
+});
+
+test('failed and cancelled agents render nothing at all: the lane never doubles as a report', async () => {
+  const state = await setup();
+  state.delegate('session-1', [agent({ id: 'd1' }), agent({ id: 'd2', agent: 'planner', description: 'Sequence the work' })]);
+  state.settle('session-1', { delegationId: 'd1', status: 'failed', agent: 'executor', description: 'Wire the WORK lane' });
+  state.settle('session-1', { delegationId: 'd2', status: 'cancelled', agent: 'planner', description: 'Sequence the work' });
+  state.publish('session-1', plan);
+  state.delegate('session-1', [agent({ id: 'd1', status: 'failed' })]);
+  render(state.ui('session-1'));
+
+  const region = section();
+  assert.equal(within(region).queryByText('Agents'), null);
+  assert.doesNotMatch(region.textContent!, /Executor|Planner|failed|cancelled/i);
+  assert.equal(within(region).getAllByRole('listitem').length, 4);
+});
+
+test('a long agent description truncates to one line and keeps the full value on the row', async () => {
+  const state = await setup();
+  const description = `${'Implement the very long delegation description/'.repeat(20)}done`;
+  state.delegate('session-1', [agent({ description })]);
+  render(state.ui('session-1'));
+
+  const row = within(section()).getByText(`Executor — ${description}`).closest('li')!;
+  assert.equal(row.getAttribute('title'), `executor: ${description}`);
+  assert.match(row.querySelector('span:last-child')!.getAttribute('class')!, /truncate/);
+});
+
+test('agents published for another conversation never appear in this one', async () => {
+  const state = await setup();
+  state.delegate('session-2', [agent({ description: 'Another conversation' })]);
+  const view = render(state.ui('session-1'));
+  assert.equal(view.container.innerHTML, '');
+
+  view.rerender(state.ui('session-2'));
+  assert.ok(within(section()).getByText('Executor — Another conversation'));
 });
 
 test('Korean headings and status labels come from the same locale data as the chat card', async () => {

--- a/src/components/agent-sidebar/view/AgentSidebarWork.tsx
+++ b/src/components/agent-sidebar/view/AgentSidebarWork.tsx
@@ -3,10 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { useSessionStatus } from '../../../contexts/SessionStatusContext';
 import type { SessionStore } from '../../../stores/useSessionStore';
 import { cn } from '../../../utils/cn';
+import { useSessionDelegations } from '../../chat/hooks/useSessionDelegations';
 import { useSessionTodos } from '../../chat/hooks/useSessionTodos';
 import { TODO_STATUS_ICON } from '../../chat/view/todoStatusIcon';
 
 const { Icon: WorkingIcon, className: workingIconClassName } = TODO_STATUS_ICON.in_progress;
+
+/** The runtime names agents in lowercase ('executor'); the lane shows them as labels. */
+const agentLabel = (agent: string) => (agent ? agent[0].toUpperCase() + agent.slice(1) : agent);
 
 export type AgentSidebarWorkProps = {
   sessionId?: string;
@@ -27,17 +31,25 @@ export type AgentSidebarWorkProps = {
  * all-completed and even while idle; a run without a list falls back to one
  * "Working" row; a session with neither is silent, so an idle session leaves
  * the Environment summary alone.
+ *
+ * Delegations follow the same rule: the lane lists the agents the runtime
+ * reports as running right now, and a settled receipt removes the row, because
+ * WORK answers "what is happening" and not "what happened". A session with
+ * running agents never also shows the generic "Working" row - the agents are
+ * the better answer to the same question.
  */
 export default function AgentSidebarWork({ sessionId, sessionStore }: AgentSidebarWorkProps) {
   const { t } = useTranslation();
   const status = useSessionStatus();
   const phases = useSessionTodos(sessionStore, sessionId, Boolean(sessionId));
+  const delegations = useSessionDelegations(sessionStore, sessionId, Boolean(sessionId));
   const hasTasks = phases.some((phase) => phase.tasks.length > 0);
+  const agents = delegations.filter((delegation) => delegation.status === 'running');
   // Only the published activity of this very session counts; a snapshot left
   // over from another conversation must never read as this one running.
   const running = Boolean(sessionId) && status.sessionId === sessionId && status.activity.running;
 
-  if (!hasTasks && !running) {
+  if (!hasTasks && !running && agents.length === 0) {
     return null;
   }
 
@@ -70,12 +82,26 @@ export default function AgentSidebarWork({ sessionId, sessionStore }: AgentSideb
             </ul>
           </div>
         ))
-      ) : (
+      ) : agents.length === 0 ? (
         // The list is the projection of record; a run without one still owes
         // the lane one line, and never a guess at what it is doing.
         <div className="flex items-center gap-2 px-2 py-1.5">
           <WorkingIcon className={cn('h-3.5 w-3.5 shrink-0', workingIconClassName)} aria-hidden />
           <span className="min-w-0 flex-1 truncate text-foreground">{t('agentSidebar.work.working')}</span>
+        </div>
+      ) : null}
+      {agents.length > 0 && (
+        <div>
+          <p className="px-2 pt-1 pb-0.5 text-[10px] font-medium tracking-wide text-muted-foreground/70">{t('agentSidebar.work.agents')}</p>
+          <ul>
+            {agents.map((agent) => (
+              <li key={agent.delegationId} className="flex items-start gap-2 px-2 py-1" title={`${agent.agent}: ${agent.description}`}>
+                <WorkingIcon className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', workingIconClassName)} aria-hidden />
+                <span className="sr-only">{t('agentSidebar.work.agentRunning')}: </span>
+                <span className="min-w-0 flex-1 truncate text-foreground">{`${agentLabel(agent.agent)} — ${agent.description}`}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </section>

--- a/src/components/chat/hooks/useSessionDelegations.test.ts
+++ b/src/components/chat/hooks/useSessionDelegations.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { NormalizedMessage } from '../../../stores/useSessionStore';
+
+import { sessionDelegations } from './useSessionDelegations';
+
+const delegationCall = (id: string, subagents: unknown, toolName = 'task'): NormalizedMessage => ({
+  id,
+  sessionId: 'session',
+  timestamp: '2026-01-01T00:00:00Z',
+  provider: 'gjc',
+  kind: 'tool_use',
+  toolId: id,
+  toolName,
+  toolInput: { agent: 'executor' },
+  toolResult: { content: 'ok', isError: false, toolUseResult: { subagents } },
+} as unknown as NormalizedMessage);
+
+const settlement = (id: string, delegation: unknown): NormalizedMessage => ({
+  id,
+  sessionId: 'session',
+  timestamp: '2026-01-01T00:01:00Z',
+  provider: 'gjc',
+  kind: 'delegation_updated',
+  delegation,
+} as unknown as NormalizedMessage);
+
+const subagent = (overrides: Record<string, unknown> = {}) => ({
+  id: 'd1', status: 'running', agent: 'executor', description: 'wire the lane', ...overrides,
+});
+
+const bareDelegationCall = (id: string, toolName = 'task'): NormalizedMessage => ({
+  id,
+  sessionId: 'session',
+  timestamp: '2026-01-01T00:00:00Z',
+  provider: 'gjc',
+  kind: 'tool_use',
+  toolId: id,
+  toolName,
+  toolInput: { agent: 'executor' },
+} as unknown as NormalizedMessage);
+
+const liveDelegationResult = (id: string, toolId: string, subagents: unknown): NormalizedMessage => ({
+  id,
+  sessionId: 'session',
+  timestamp: '2026-01-01T00:00:30Z',
+  provider: 'gjc',
+  kind: 'tool_result',
+  toolId,
+  content: 'ok',
+  isError: false,
+  isFinal: true,
+  toolUseResult: { subagents },
+} as unknown as NormalizedMessage);
+
+test('a running delegation in a task tool result becomes one active snapshot', () => {
+  assert.deepEqual(sessionDelegations([delegationCall('t1', [subagent()])]), [
+    { delegationId: 'd1', status: 'running', agent: 'executor', description: 'wire the lane' },
+  ]);
+});
+
+test('several agents of one call are all reported, in the order the runtime lists them', () => {
+  const delegations = sessionDelegations([delegationCall('t1', [
+    subagent({ id: 'd1', agent: 'planner', description: 'sequence the work' }),
+    subagent({ id: 'd2', agent: 'executor', description: 'server lane', executionMode: 'ultragoal-red-team', repositoryBinding: { root: '/repo' } }),
+  ], 'subagent')]);
+
+  assert.deepEqual(delegations.map((delegation) => delegation.delegationId), ['d1', 'd2']);
+  assert.deepEqual(delegations[1], {
+    delegationId: 'd2', status: 'running', agent: 'executor', description: 'server lane',
+    executionMode: 'ultragoal-red-team', repositoryBinding: { root: '/repo' },
+  });
+});
+
+for (const status of ['completed', 'failed', 'cancelled'] as const) {
+  test(`a later ${status} receipt settles the delegation and leaves nothing running`, () => {
+    const delegations = sessionDelegations([
+      delegationCall('t1', [subagent()]),
+      settlement('r1', { delegationId: 'd1', status, agent: 'executor', description: 'wire the lane' }),
+    ]);
+
+    assert.equal(delegations.length, 1);
+    assert.equal(delegations[0].status, status);
+    assert.equal(delegations.filter((delegation) => delegation.status === 'running').length, 0);
+  });
+}
+
+test('a stale running tool-result snapshot is superseded by the later receipt row', () => {
+  const delegations = sessionDelegations([
+    settlement('r1', { delegationId: 'd1', status: 'running', agent: 'executor', description: 'wire the lane' }),
+    delegationCall('t1', [subagent({ status: 'running', description: 'wire the lane' })]),
+    settlement('r2', { delegationId: 'd1', status: 'completed', agent: 'executor', description: 'wire the lane' }),
+  ]);
+
+  assert.deepEqual(delegations, [{ delegationId: 'd1', status: 'completed', agent: 'executor', description: 'wire the lane' }]);
+});
+
+test('a resumed delegation reuses its ID and reads as running again: terminal state is not sticky', () => {
+  const delegations = sessionDelegations([
+    settlement('r1', { delegationId: 'd1', status: 'completed', agent: 'executor', description: 'wire the lane' }),
+    settlement('r2', { delegationId: 'd1', status: 'running', agent: 'executor', description: 'wire the lane, round two' }),
+  ]);
+
+  assert.deepEqual(delegations, [{ delegationId: 'd1', status: 'running', agent: 'executor', description: 'wire the lane, round two' }]);
+});
+
+test('a replayed update is idempotent: the same row twice is still one delegation', () => {
+  const row = settlement('r1', { delegationId: 'd1', status: 'running', agent: 'executor', description: 'wire the lane' });
+  assert.equal(sessionDelegations([row, row]).length, 1);
+});
+
+test('the fold reads only the window it is given', () => {
+  const mine = delegationCall('t1', [subagent({ id: 'mine' })]);
+  const theirs = delegationCall('t2', [subagent({ id: 'theirs' })]);
+
+  assert.deepEqual(sessionDelegations([mine]).map((delegation) => delegation.delegationId), ['mine']);
+  assert.deepEqual(sessionDelegations([theirs]).map((delegation) => delegation.delegationId), ['theirs']);
+  assert.deepEqual(sessionDelegations([]), []);
+});
+
+test('malformed rows contribute nothing rather than a half-known agent', () => {
+  assert.deepEqual(sessionDelegations([
+    delegationCall('t1', 'not-an-array'),
+    delegationCall('t2', [
+      subagent({ id: '' }),
+      subagent({ id: 42 }),
+      subagent({ status: 'queued' }),
+      subagent({ status: undefined }),
+      subagent({ agent: '' }),
+      subagent({ description: 7 }),
+      'garbage',
+      null,
+    ]),
+    settlement('r1', { delegationId: 'd1', status: 'running', agent: 'executor' }),
+    settlement('r2', { id: 'd1', status: 'running', agent: 'executor', description: 'wrong id key' }),
+    settlement('r3', null),
+    settlement('r4', 'nope'),
+  ]), []);
+});
+
+test('an unknown execution mode is dropped without dropping the delegation', () => {
+  assert.deepEqual(sessionDelegations([delegationCall('t1', [subagent({ executionMode: 'wild-mode' })])]), [
+    { delegationId: 'd1', status: 'running', agent: 'executor', description: 'wire the lane' },
+  ]);
+});
+
+test('tool results that are not delegations never contribute', () => {
+  assert.deepEqual(sessionDelegations([
+    { kind: 'text', role: 'assistant', content: 'spawning the executor subagent now' } as unknown as NormalizedMessage,
+    delegationCall('t1', [subagent()], 'todo_write'),
+    delegationCall('t2', [subagent({ id: 'd2' })], 'bash'),
+  ]), []);
+});
+
+test('a live stream result row pairs back to its delegation call by toolId', () => {
+  const delegations = sessionDelegations([
+    bareDelegationCall('t1'),
+    liveDelegationResult('r1', 't1', [subagent()]),
+    settlement('r2', { delegationId: 'd1', status: 'completed', agent: 'executor', description: 'wire the lane' }),
+  ]);
+
+  assert.deepEqual(delegations, [{ delegationId: 'd1', status: 'completed', agent: 'executor', description: 'wire the lane' }]);
+});
+
+test('a result row whose call is not a delegation tool never contributes', () => {
+  assert.deepEqual(sessionDelegations([
+    bareDelegationCall('t1', 'bash'),
+    liveDelegationResult('r1', 't1', [subagent()]),
+    liveDelegationResult('r2', 'unknown-call', [subagent()]),
+  ]), []);
+});

--- a/src/components/chat/hooks/useSessionDelegations.ts
+++ b/src/components/chat/hooks/useSessionDelegations.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+import type { DelegationSnapshot, NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+
+export type SessionDelegation = DelegationSnapshot;
+
+const EMPTY_MESSAGES: NormalizedMessage[] = [];
+const EMPTY_DELEGATIONS: SessionDelegation[] = [];
+
+const STATUSES = new Set(['running', 'completed', 'failed', 'cancelled']);
+const EXECUTION_MODES = new Set(['default', 'ultragoal-red-team']);
+
+const isDelegationToolName = (toolName: string | undefined) => toolName === 'task' || toolName === 'subagent';
+
+/**
+ * Accepts only a fully formed public snapshot. A row that is missing the
+ * identity, the agent or the settlement status carries no truth about what is
+ * running, so it is dropped rather than rendered as a half-known agent.
+ */
+const snapshotFrom = (candidate: unknown, idKey: 'id' | 'delegationId'): SessionDelegation | null => {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const row = candidate as Record<string, unknown>;
+  const delegationId = row[idKey];
+  const { status, agent, description, executionMode, repositoryBinding } = row;
+  if (typeof delegationId !== 'string' || !delegationId) return null;
+  if (typeof status !== 'string' || !STATUSES.has(status)) return null;
+  if (typeof agent !== 'string' || !agent) return null;
+  if (typeof description !== 'string') return null;
+  return {
+    delegationId,
+    status: status as SessionDelegation['status'],
+    agent,
+    description,
+    ...(typeof executionMode === 'string' && EXECUTION_MODES.has(executionMode)
+      ? { executionMode: executionMode as SessionDelegation['executionMode'] }
+      : {}),
+    ...(repositoryBinding !== undefined ? { repositoryBinding } : {}),
+  };
+};
+
+/**
+ * The session's App-owned delegations, folded from the message window in
+ * array order (the store merges chronologically), last write per delegation
+ * wins.
+ *
+ * Exactly two sources are authoritative: the `subagents` array the delegation
+ * tool returns in its structured result, and the `delegation_updated`
+ * settlement rows the executor emits per receipt. The result reaches the
+ * window in two shapes: the reloaded transcript attaches it to its `tool_use`
+ * row, while the live stream carries it as a standalone `tool_result` row that
+ * only a shared `toolId` ties back to the call. Nothing is inferred from
+ * timing, prose or tool counts, and a terminal state is not sticky - a resume
+ * legitimately reuses the same ID with a new `running` state, which
+ * chronological last-wins already expresses.
+ */
+export function sessionDelegations(messages: readonly NormalizedMessage[]): SessionDelegation[] {
+  const delegationToolIds = new Set<string>();
+  for (const message of messages) {
+    if (message.kind === 'tool_use' && message.toolId && isDelegationToolName(message.toolName)) {
+      delegationToolIds.add(message.toolId);
+    }
+  }
+  const byId = new Map<string, SessionDelegation>();
+  for (const message of messages) {
+    if (message.kind === 'tool_use' && isDelegationToolName(message.toolName)) {
+      const details = message.toolResult?.toolUseResult as { subagents?: unknown } | undefined;
+      if (!details || typeof details !== 'object' || !Array.isArray(details.subagents)) continue;
+      for (const entry of details.subagents) {
+        const snapshot = snapshotFrom(entry, 'id');
+        if (snapshot) byId.set(snapshot.delegationId, snapshot);
+      }
+      continue;
+    }
+    if (message.kind === 'tool_result' && message.toolId && delegationToolIds.has(message.toolId)) {
+      const details = message.toolUseResult as { subagents?: unknown } | undefined;
+      if (!details || typeof details !== 'object' || !Array.isArray(details.subagents)) continue;
+      for (const entry of details.subagents) {
+        const snapshot = snapshotFrom(entry, 'id');
+        if (snapshot) byId.set(snapshot.delegationId, snapshot);
+      }
+      continue;
+    }
+    if (message.kind === 'delegation_updated') {
+      const snapshot = snapshotFrom(message.delegation, 'delegationId');
+      if (snapshot) byId.set(snapshot.delegationId, snapshot);
+    }
+  }
+  return byId.size ? [...byId.values()] : EMPTY_DELEGATIONS;
+}
+
+/** Latest delegation state for the visible chat, re-read when its messages change. */
+export function useSessionDelegations(sessionStore: SessionStore, sessionId: string | undefined, enabled: boolean): SessionDelegation[] {
+  const { getMessages, subscribeSession } = sessionStore;
+  const subscribe = useCallback(
+    (listener: () => void) => (sessionId ? subscribeSession(sessionId, listener) : () => {}),
+    [sessionId, subscribeSession],
+  );
+  const read = useCallback(() => (sessionId ? getMessages(sessionId) : EMPTY_MESSAGES), [getMessages, sessionId]);
+  const messages = useSyncExternalStore(subscribe, read, read);
+  return useMemo(() => (enabled && sessionId ? sessionDelegations(messages) : EMPTY_DELEGATIONS), [enabled, sessionId, messages]);
+}

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "Arbeit",
-      "working": "Läuft"
+      "working": "Läuft",
+      "agents": "Agenten",
+      "agentRunning": "Wird ausgeführt"
     },
     "actionRequired": {
       "title": "Antwort erforderlich",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "Work",
-      "working": "Working"
+      "working": "Working",
+      "agents": "Agents",
+      "agentRunning": "Running"
     },
     "actionRequired": {
       "title": "Action required",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "Travail",
-      "working": "En cours"
+      "working": "En cours",
+      "agents": "Agents",
+      "agentRunning": "En cours"
     },
     "actionRequired": {
       "title": "Réponse requise",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "Lavoro",
-      "working": "In corso"
+      "working": "In corso",
+      "agents": "Agenti",
+      "agentRunning": "In esecuzione"
     },
     "actionRequired": {
       "title": "Risposta richiesta",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "作業",
-      "working": "実行中"
+      "working": "実行中",
+      "agents": "エージェント",
+      "agentRunning": "実行中"
     },
     "actionRequired": {
       "title": "応答が必要",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "작업",
-      "working": "작업 중"
+      "working": "작업 중",
+      "agents": "에이전트",
+      "agentRunning": "실행 중"
     },
     "actionRequired": {
       "title": "응답 필요",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "Работа",
-      "working": "Выполняется"
+      "working": "Выполняется",
+      "agents": "Агенты",
+      "agentRunning": "Выполняется"
     },
     "actionRequired": {
       "title": "Требуется ответ",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "İş",
-      "working": "Çalışıyor"
+      "working": "Çalışıyor",
+      "agents": "Aracılar",
+      "agentRunning": "Çalışıyor"
     },
     "actionRequired": {
       "title": "Yanıt gerekiyor",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "工作",
-      "working": "正在执行"
+      "working": "正在执行",
+      "agents": "代理",
+      "agentRunning": "运行中"
     },
     "actionRequired": {
       "title": "需要回复",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -94,7 +94,9 @@
     },
     "work": {
       "title": "工作",
-      "working": "運行中"
+      "working": "運行中",
+      "agents": "代理",
+      "agentRunning": "執行中"
     },
     "actionRequired": {
       "title": "需要回覆",

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -7,7 +7,21 @@ import { authenticatedFetch } from '../utils/api';
 
 import { buildRefreshMessagesUrl, shareMessageWindow } from './sessionMessageFetch';
 
-type MessageKind = 'text' | 'tool_use' | 'tool_result' | 'thinking' | 'stream_delta' | 'stream_end' | 'error' | 'complete' | 'status' | 'permission_request' | 'permission_cancelled' | 'session_created' | 'interactive_prompt' | 'task_notification' | 'system_notice';
+type MessageKind = 'text' | 'tool_use' | 'tool_result' | 'thinking' | 'stream_delta' | 'stream_end' | 'error' | 'complete' | 'status' | 'permission_request' | 'permission_cancelled' | 'session_created' | 'interactive_prompt' | 'task_notification' | 'system_notice' | 'delegation_updated';
+/**
+ * The public snapshot of an App-owned delegation, as the durable receipt in
+ * the owner transcript records it. It is deliberately the settlement signal
+ * only: no result text, file, owner, root or child session ID ever reaches
+ * the client.
+ */
+export type DelegationSnapshot = {
+  delegationId: string;
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  agent: string;
+  description: string;
+  executionMode?: 'default' | 'ultragoal-red-team';
+  repositoryBinding?: unknown;
+};
 export interface NormalizedMessage {
   id: string; sessionId: string; timestamp: string; provider: LLMProvider; kind: MessageKind; seq?: number; replayGeneration?: string;
   role?: 'user' | 'assistant'; content?: string; displayText?: string; commandName?: string; commandMessage?: string; commandArgs?: string;
@@ -16,6 +30,7 @@ export interface NormalizedMessage {
   toolResultTruncated?: boolean; toolResultBytes?: number; isError?: boolean; level?: 'info' | 'warning' | 'error'; text?: string; tokens?: number;
   canInterrupt?: boolean; tokenBudget?: unknown; requestId?: string; input?: unknown; context?: unknown; newSessionId?: string; status?: string;
   summary?: string; exitCode?: number; actualSessionId?: string; parentToolUseId?: string; subagentTools?: unknown[]; isFinal?: boolean; sequence?: number; rowid?: number;
+  delegation?: DelegationSnapshot;
 }
 export type SessionStatus = 'idle' | 'loading' | 'streaming' | 'error';
 export type ChatReplayCursor = { replayGeneration: string | null; lastSeq: number };


### PR DESCRIPTION
## Summary

Completes the delegation lifecycle contract from `docs/plans/delegation-lifecycle-contract.md` (#78 audit, verdict `MINIMAL_CONTRACT_REQUIRED`): App-owned delegations (`GjcDelegationExecutor`) now appear truthfully and live in the sidebar WORK lane, including settlement and reload/reconnect, with the durable receipt as the only authority.

## What changed

**1. Live settlement signal (server, engine)**
- `GjcDelegationOptions.onDelegationSettled` — fired exactly once per settlement from `#run`'s `finally` block, immediately *after* the durable terminal receipt append + flush, carrying only the public snapshot (`delegationId`, `status`, `agent`, `description`, `executionMode?`, `repositoryBinding?`). Never `resultText`, `owner`, `root`, `childSessionId`, `file`. Covers completed / failed / cancelled / dispose-driven cancellation; no launch event (the `task` tool result already transports the running snapshot); no queued/starting states (they don't exist).
- Adapter wires it to the run writer as `{kind: 'delegation_updated', delegation}`; `gjc-worker.ts #normalized` maps it to the new scoped worker event `delegation.updated` (`GJC_WORKER_EVENT_METHODS`); the worker-client's generic `payload.message` relay forwards it unchanged. Older clients that ignore the kind are unaffected.

**2. Durable receipt projection (server, providers)**
- `readGjcDelegationReceipt` — deliberately narrow reader: only `customType: 'gajae-app.delegation.v1'`, only public fields; every other custom transcript entry stays invisible.
- `gjc-sessions.provider.ts` projects receipts as `delegation_updated` history rows and applies the executor's own restart rule at read time: a `running` receipt is trusted only while `chatRunRegistry.isProcessing(appSessionId)`; otherwise it reads `cancelled`. A permanently-running sidebar row after restart is therefore impossible.
- Export renderer explicitly skips the lifecycle row kind.

**3. Client fold**
- `useSessionDelegations` (mirrors `useSessionTodos`): folds the merged message window chronologically, last write per `delegationId` wins, from exactly two authoritative sources — `task`/`subagent` tool results (`toolUseResult.subagents`, both the reload-attached shape and the live standalone `tool_result` row paired by `toolId`) and `delegation_updated` rows. No terminal stickiness, so `subagent resume` (same id) works. No inference from timing, prose, or tool counts.

**4. WORK UI**
- `AgentSidebarWork` lists running agents under a compact `Agents` sublabel: spinner icon + sr-only "Running" + `Agent — description` (truncated, full text on `title`). Terminal delegations disappear at settlement; no timers, no history (the transcript/tool card remains the history).
- Fallback matrix: tasks+agents → both, no `Working`; agents only → agent rows, no `Working`; no tasks/agents + running → existing `Working`; idle → absent. ACTION REQUIRED semantics untouched (delegation authorization stays an ordinary permission request; failed/cancelled children never become attention items).

## Verification

- `npm run verify` — full gate green (audit, typecheck, check:core, test, lint, check:identity, build).
- `npm run test:e2e:gjc` — 8/8 green.
- Focused: `gjc-delegation-executor.bun.test.ts` 31/31 (new: exactly-one settle notification per completed/failed/cancel/dispose path, receipt durable before the signal, no private fields); worker protocol/spec/host suites 109/109 across the touched server files; `gjc-sessions.test.ts` +3 (receipt pair ordering, restart-vs-live fold, other custom entries invisible, no secret leakage, export exclusion); `useSessionDelegations.test.ts` 14 cases; `AgentSidebarWork.dom.bun.test.tsx` 23/23 (visibility matrix, live settle removal, multi-agent, truncation, cross-session isolation).
- Isolated HTTP smoke (own port 3199 + own DATABASE_PATH, shared `gajae-dev` untouched): seeded a transcript with a running→completed receipt pair and a stale running receipt; REST history returns the terminal state and folds the stale running receipt to `cancelled`; receipt-private fields never serialize.

## Out of scope (unchanged by design)

No SDK-native task system, no IRC, no Aside/browser changes, no new store/database/localStorage, no child progress streaming. `docs/plans/delegation-lifecycle-contract.md` and `docs/plans/agent-sidebar-activity-model.md` carry implementation status notes.
